### PR TITLE
fix: pause menu and terminal UI not showing

### DIFF
--- a/crates/client/src/plugins/debug_console.rs
+++ b/crates/client/src/plugins/debug_console.rs
@@ -40,16 +40,17 @@ fn draw_debug_console(
     mut ctx: EguiContexts,
     mut console: ResMut<DebugConsole>,
     mut player_q: LocalPlayerQuery,
+    keyboard: Res<ButtonInput<KeyCode>>,
 ) -> Result {
-    let egui_ctx = ctx.ctx_mut()?;
-
-    if egui_ctx.input(|i| i.key_pressed(egui::Key::Backtick)) {
+    if keyboard.just_pressed(KeyCode::Backquote) {
         console.open = !console.open;
         if console.open {
             console.input.clear();
             console.request_focus = true;
         }
     }
+
+    let egui_ctx = ctx.ctx_mut()?;
 
     if !console.open {
         return Ok(());

--- a/crates/client/src/plugins/pause_menu.rs
+++ b/crates/client/src/plugins/pause_menu.rs
@@ -18,12 +18,13 @@ impl Plugin for PauseMenuPlugin {
 fn draw_pause_menu(
     mut ctx: EguiContexts,
     mut menu: ResMut<PauseMenu>,
+    keyboard: Res<ButtonInput<KeyCode>>,
 ) -> Result {
-    let egui_ctx = ctx.ctx_mut()?;
-
-    if egui_ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+    if keyboard.just_pressed(KeyCode::Escape) {
         menu.open = !menu.open;
     }
+
+    let egui_ctx = ctx.ctx_mut()?;
 
     if !menu.open {
         return Ok(());


### PR DESCRIPTION
Fixes #4

Use Bevy's `ButtonInput::just_pressed` instead of egui's `key_pressed` for toggling pause menu and debug console. egui's `key_pressed` fires on OS key-repeat events, causing rapid oscillation that made windows invisible.

Generated with [Claude Code](https://claude.ai/code)