### PR TITLE
Wire ralph E2E infrastructure: --combat-test, DM BRP methods, TestHarness

### DIFF
--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -74,29 +74,50 @@ fn main() {
 
     #[cfg(not(target_family = "wasm"))]
     {
-        let headless = args.iter().any(|a| a == "--headless");
+        let headless    = args.iter().any(|a| a == "--headless");
+        let combat_test = args.iter().any(|a| a == "--combat-test");
         if headless {
             tracing_subscriber::fmt::init();
             app.add_plugins(MinimalPlugins)
-                .add_plugins(RemotePlugin::default())
+                .add_plugins(
+                    RemotePlugin::default()
+                        .register_method("dm/spawn_npc",         fellytip_server::plugins::dm::dm_spawn_npc)
+                        .register_method("dm/kill",              fellytip_server::plugins::dm::dm_kill)
+                        .register_method("dm/teleport",          fellytip_server::plugins::dm::dm_teleport)
+                        .register_method("dm/set_faction",       fellytip_server::plugins::dm::dm_set_faction)
+                        .register_method("dm/trigger_war_party", fellytip_server::plugins::dm::dm_trigger_war_party)
+                        .register_method("dm/set_ecology",       fellytip_server::plugins::dm::dm_set_ecology)
+                )
                 .add_plugins(RemoteHttpPlugin::default().with_port(BRP_PORT))
                 .add_systems(Update, (headless_auto_attack, headless_auto_move));
         } else {
             add_windowed_plugins(&mut app);
         }
+        app.add_plugins(FellytipProtocolPlugin)
+            .add_plugins(ServerGamePlugin {
+                seed,
+                width:               map_width,
+                height:              map_height,
+                history_warp_ticks:  history_warp,
+                npcs_per_faction:    npcs_per_fac,
+                combat_test,
+            });
     }
     #[cfg(target_family = "wasm")]
-    add_windowed_plugins(&mut app);
+    {
+        add_windowed_plugins(&mut app);
+        app.add_plugins(FellytipProtocolPlugin)
+            .add_plugins(ServerGamePlugin {
+                seed,
+                width:               map_width,
+                height:              map_height,
+                history_warp_ticks:  history_warp,
+                npcs_per_faction:    npcs_per_fac,
+                combat_test: false,
+            });
+    }
 
-    app.add_plugins(FellytipProtocolPlugin)
-        .add_plugins(ServerGamePlugin {
-            seed,
-            width:               map_width,
-            height:              map_height,
-            history_warp_ticks:  history_warp,
-            npcs_per_faction:    npcs_per_fac,
-        })
-        .configure_sets(
+    app.configure_sets(
             Update,
             (ClientSet::Input, ClientSet::SyncVisuals, ClientSet::SyncCamera).chain(),
         )

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -28,6 +28,9 @@ pub fn parse_arg<T: std::str::FromStr>(args: &[String], flag: &str, default: T) 
 /// Does NOT add networking (ServerPlugins/ClientPlugins/FellytipProtocolPlugin)
 /// — callers add those separately for multiplayer builds.
 ///
+/// When `combat_test` is true, skips map gen, ecology, AI, and dungeon plugins
+/// and adds `CombatTestPlugin` instead for a minimal two-entity combat world.
+///
 /// MULTIPLAYER: restore ServerPlugins, spawn_server, on_client_connected,
 /// on_client_disconnected, on_link_spawned, send_greet_msg, and idle_shutdown.
 pub struct ServerGamePlugin {
@@ -36,6 +39,7 @@ pub struct ServerGamePlugin {
     pub height: usize,
     pub history_warp_ticks: u64,
     pub npcs_per_faction: usize,
+    pub combat_test: bool,
 }
 
 impl Plugin for ServerGamePlugin {
@@ -51,14 +55,19 @@ impl Plugin for ServerGamePlugin {
             .add_plugins(plugins::world_sim::WorldSimPlugin)
             .add_plugins(plugins::story::StoryPlugin)
             .add_plugins(plugins::combat::CombatPlugin)
-            .add_plugins(plugins::map_gen::MapGenPlugin)
-            .add_plugins(plugins::ecology::EcologyPlugin)
-            .add_plugins(plugins::ai::AiPlugin)
             .add_plugins(plugins::interest::InterestPlugin)
-            .add_plugins(plugins::party::PartyPlugin)
-            .add_plugins(plugins::dungeon::DungeonPlugin)
-            .add_systems(Startup, plugins::ai::seed_factions)
-            .add_systems(PostStartup, spawn_local_player);
+            .add_plugins(plugins::party::PartyPlugin);
+
+        if self.combat_test {
+            app.add_plugins(plugins::combat_test::CombatTestPlugin);
+        } else {
+            app.add_plugins(plugins::map_gen::MapGenPlugin)
+                .add_plugins(plugins::ecology::EcologyPlugin)
+                .add_plugins(plugins::ai::AiPlugin)
+                .add_plugins(plugins::dungeon::DungeonPlugin)
+                .add_systems(Startup, plugins::ai::seed_factions)
+                .add_systems(PostStartup, spawn_local_player);
+        }
     }
 }
 

--- a/tools/ralph/src/brp.rs
+++ b/tools/ralph/src/brp.rs
@@ -89,4 +89,27 @@ impl BrpClient {
     pub fn ping(&self) -> bool {
         self.call("world.list_resources", json!({})).is_ok()
     }
+
+    /// `dm/spawn_npc` — spawn a faction NPC at the given position.
+    /// Returns the spawned entity's bit-packed ID.
+    pub fn dm_spawn_npc(&self, faction: &str, x: f32, y: f32, z: f32) -> Result<u64> {
+        let result = self.call("dm/spawn_npc", json!({ "faction": faction, "x": x, "y": y, "z": z }))?;
+        result["entity"]
+            .as_u64()
+            .ok_or_else(|| anyhow::anyhow!("dm/spawn_npc: missing 'entity' in response"))
+    }
+
+    /// `dm/kill` — despawn an entity by its bit-packed ID.
+    #[allow(dead_code)]
+    pub fn dm_kill(&self, entity: u64) -> Result<()> {
+        self.call("dm/kill", json!({ "entity": entity }))?;
+        Ok(())
+    }
+
+    /// `dm/teleport` — move an entity to a new world position.
+    #[allow(dead_code)]
+    pub fn dm_teleport(&self, entity: u64, x: f32, y: f32, z: f32) -> Result<()> {
+        self.call("dm/teleport", json!({ "entity": entity, "x": x, "y": y, "z": z }))?;
+        Ok(())
+    }
 }

--- a/tools/ralph/src/harness.rs
+++ b/tools/ralph/src/harness.rs
@@ -1,0 +1,55 @@
+//! Process lifecycle harness for self-contained ralph scenarios.
+//!
+//! `TestHarness` spawns a headless `fellytip-client` process and blocks until
+//! BRP responds, then kills the process when dropped.  The 120-second timeout
+//! handles cold `cargo run` builds.
+
+use anyhow::{Result, bail};
+use std::{
+    process::{Child, Command},
+    thread::sleep,
+    time::{Duration, Instant},
+};
+
+use crate::brp::BrpClient;
+
+const BRP_STARTUP_TIMEOUT: Duration = Duration::from_secs(120);
+const POLL: Duration = Duration::from_millis(500);
+
+pub struct TestHarness {
+    process: Child,
+}
+
+impl TestHarness {
+    /// Spawns `cargo run -p fellytip-client -- --headless [extra_args]`
+    /// and blocks until BRP responds to ping (up to 120 s for build + startup).
+    pub fn start(extra_args: &[&str]) -> Result<Self> {
+        let mut cmd = Command::new("cargo");
+        cmd.args(["run", "-p", "fellytip-client", "--", "--headless"]);
+        for arg in extra_args {
+            cmd.arg(arg);
+        }
+        let process = cmd.spawn()?;
+
+        let client = BrpClient::server();
+        let deadline = Instant::now() + BRP_STARTUP_TIMEOUT;
+        tracing::info!("TestHarness: waiting for BRP at localhost:15702 (up to 120 s) …");
+        loop {
+            if client.ping() {
+                tracing::info!("TestHarness: server is up");
+                return Ok(Self { process });
+            }
+            if Instant::now() > deadline {
+                bail!("TestHarness: server BRP not reachable within {BRP_STARTUP_TIMEOUT:?}");
+            }
+            sleep(POLL);
+        }
+    }
+}
+
+impl Drop for TestHarness {
+    fn drop(&mut self) {
+        self.process.kill().ok();
+        self.process.wait().ok();
+    }
+}

--- a/tools/ralph/src/main.rs
+++ b/tools/ralph/src/main.rs
@@ -1,4 +1,5 @@
 mod brp;
+mod harness;
 mod scenarios;
 
 use scenarios::{Scenario, all_scenarios, find_scenario};

--- a/tools/ralph/src/scenarios/mod.rs
+++ b/tools/ralph/src/scenarios/mod.rs
@@ -1,5 +1,6 @@
 pub mod basic_movement;
 pub mod combat_resolves;
+pub mod npc_spawn_with_dm;
 pub mod player_moves;
 
 use anyhow::Result;
@@ -14,6 +15,7 @@ pub fn all_scenarios() -> Vec<Box<dyn Scenario>> {
         Box::new(basic_movement::BasicMovement),
         Box::new(combat_resolves::CombatResolves),
         Box::new(player_moves::PlayerMoves),
+        Box::new(npc_spawn_with_dm::NpcSpawnWithDm),
     ]
 }
 

--- a/tools/ralph/src/scenarios/npc_spawn_with_dm.rs
+++ b/tools/ralph/src/scenarios/npc_spawn_with_dm.rs
@@ -1,0 +1,79 @@
+//! Scenario: self-contained NPC spawn + damage verification via DM BRP methods.
+//!
+//! Pattern: start → inject state via DM → verify outcome → teardown.
+//!
+//! ```bash
+//! cargo run -p ralph -- --scenario npc_spawn_with_dm
+//! ```
+//!
+//! The scenario launches its own headless server, uses `dm/spawn_npc` to place
+//! an Iron Wolves NPC adjacent to the player, then waits for `headless_auto_attack`
+//! (fires every 2 s) to damage it.  The harness kills the server on drop.
+
+use crate::{Scenario, brp::BrpClient, harness::TestHarness};
+use anyhow::{Result, bail};
+use std::{thread::sleep, time::{Duration, Instant}};
+
+pub struct NpcSpawnWithDm;
+
+const TIMEOUT: Duration = Duration::from_secs(15);
+const POLL: Duration = Duration::from_millis(250);
+
+const WORLD_POSITION: &str = "fellytip_shared::components::WorldPosition";
+const EXPERIENCE:     &str = "fellytip_shared::components::Experience";
+const HEALTH:         &str = "fellytip_shared::components::Health";
+
+impl Scenario for NpcSpawnWithDm {
+    fn name(&self) -> &str {
+        "npc_spawn_with_dm"
+    }
+
+    fn run(&self) -> Result<()> {
+        // ── 1. Start a fresh headless server ─────────────────────────────────
+        let _harness = TestHarness::start(&[])?;
+        let server = BrpClient::server();
+
+        // ── 2. Poll for player entity (WorldPosition + Experience) ────────────
+        tracing::info!("Polling for player entity (WorldPosition + Experience) …");
+        let deadline = Instant::now() + TIMEOUT;
+        let (px, py, pz) = loop {
+            let entities = server.query(&[WORLD_POSITION, EXPERIENCE])?;
+            if let Some(e) = entities.first() {
+                let x = e["components"][WORLD_POSITION]["x"].as_f64().unwrap_or(0.0) as f32;
+                let y = e["components"][WORLD_POSITION]["y"].as_f64().unwrap_or(0.0) as f32;
+                let z = e["components"][WORLD_POSITION]["z"].as_f64().unwrap_or(0.0) as f32;
+                tracing::info!(x, y, z, "Found player entity");
+                break (x, y, z);
+            }
+            if Instant::now() > deadline {
+                bail!("No player entity found within {TIMEOUT:?}");
+            }
+            sleep(POLL);
+        };
+
+        // ── 3. DM-spawn an NPC adjacent to the player ─────────────────────────
+        let npc_entity = server.dm_spawn_npc("iron_wolves", px + 2.0, py, pz)?;
+        tracing::info!(npc_entity, "DM spawned Iron Wolves NPC adjacent to player");
+
+        // ── 4. Wait for the NPC to take damage ────────────────────────────────
+        tracing::info!("Waiting for NPC to take damage (headless_auto_attack fires every 2 s) …");
+        let deadline = Instant::now() + TIMEOUT;
+        loop {
+            let entities = server.query(&[HEALTH])?;
+            for e in &entities {
+                if e["entity"].as_u64().unwrap_or(0) != npc_entity { continue; }
+                let max_hp  = e["components"][HEALTH]["max"].as_i64().unwrap_or(0);
+                let current = e["components"][HEALTH]["current"].as_i64().unwrap_or(max_hp);
+                if max_hp > 0 && current < max_hp {
+                    tracing::info!(npc_entity, current, max_hp, "PASS: NPC took damage");
+                    return Ok(());
+                }
+            }
+            if Instant::now() > deadline {
+                bail!("NPC did not take damage within {TIMEOUT:?}");
+            }
+            sleep(POLL);
+        }
+        // ── 5. _harness drops here → server killed ────────────────────────────
+    }
+}


### PR DESCRIPTION
Wire all three pieces of E2E infrastructure described in issue #3:

- `--combat-test` flag now activates `CombatTestPlugin` and skips map gen, ecology, AI, dungeon
- All 6 DM BRP methods registered on `RemotePlugin` in headless mode
- `BrpClient` gains `dm_spawn_npc`, `dm_kill`, `dm_teleport` wrappers
- New `TestHarness` manages subprocess lifecycle with 120 s BRP startup timeout
- New self-contained `npc_spawn_with_dm` scenario demonstrates start→inject→verify→teardown pattern

Closes #3

Generated with [Claude Code](https://claude.ai/code)