### PR TITLE
feat(render): lock isometric camera behind locked_iso feature (#15)

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 
 [features]
 debug = []
+# Fixed-orientation zoomable isometric camera.  When enabled, right/middle-click
+# drag no longer rotates the view — only scroll-wheel zoom is active.  Leaving
+# this off keeps the orbit camera useful for top-down debugging.
+locked_iso = []
 
 [dependencies]
 fellytip-shared    = { workspace = true }

--- a/crates/client/src/plugins/camera.rs
+++ b/crates/client/src/plugins/camera.rs
@@ -2,18 +2,26 @@
 //!
 //! Default angle: yaw=45°, pitch=35.3° (classic isometric).  The target starts
 //! at the centre of the world map so the player sees terrain immediately.
+//!
+//! With the `locked_iso` cargo feature enabled, drag-to-orbit is disabled —
+//! yaw and pitch stay at the dimetric iso angles and only scroll zoom is live.
 
-use std::f32::consts::PI;
-use bevy::{
-    input::mouse::{AccumulatedMouseMotion, AccumulatedMouseScroll},
-    prelude::*,
-};
+use bevy::input::mouse::AccumulatedMouseScroll;
+#[cfg(not(feature = "locked_iso"))]
+use bevy::input::mouse::AccumulatedMouseMotion;
+use bevy::prelude::*;
 use fellytip_shared::world::map::WorldMap;
+use std::f32::consts::PI;
 use crate::{ClientSet, LocalPlayer, PredictedPosition};
 use crate::plugins::terrain::chunk::vertex_height;
 
 /// Minimum world-unit clearance between the camera and the terrain surface below it.
 const TERRAIN_CLEARANCE: f32 = 3.0;
+
+/// True dimetric isometric yaw (45°).
+pub const ISO_YAW: f32 = PI * 0.25;
+/// True dimetric isometric pitch (≈35.264°, `atan(1/√2)`).
+pub const ISO_PITCH: f32 = 0.615_479_7;
 
 pub struct OrbitCameraPlugin;
 
@@ -26,6 +34,7 @@ impl Plugin for OrbitCameraPlugin {
 
 /// Logical orbit state.  The Bevy `Transform` is recomputed every frame.
 #[derive(Component)]
+#[cfg_attr(feature = "locked_iso", allow(dead_code))]
 pub struct OrbitCamera {
     /// World-space point the camera orbits around (Bevy Y-up coordinates).
     pub target: Vec3,
@@ -53,8 +62,8 @@ impl Default for OrbitCamera {
             // with Z_SCALE=20.0 and moderate terrain height.
             target: Vec3::new(0.0, 8.0, 0.0),
             distance: 14.0,
-            yaw: PI * 0.25,   // 45° diagonal — isometric
-            pitch: 0.615,     // ~35.3° — classic isometric elevation
+            yaw: ISO_YAW,
+            pitch: ISO_PITCH,
             min_pitch: 0.40,
             max_pitch: PI * 0.5 - 0.02,
             min_distance: 2.0,
@@ -84,8 +93,8 @@ fn spawn_camera(mut commands: Commands) {
 
 fn update_orbit_camera(
     mut query: Query<(&mut OrbitCamera, &mut Transform)>,
-    buttons: Res<ButtonInput<MouseButton>>,
-    motion: Res<AccumulatedMouseMotion>,
+    #[cfg(not(feature = "locked_iso"))] buttons: Res<ButtonInput<MouseButton>>,
+    #[cfg(not(feature = "locked_iso"))] motion: Res<AccumulatedMouseMotion>,
     scroll: Res<AccumulatedMouseScroll>,
     // Follow the local player's predicted position — updated every frame on
     // input so the camera tracks the visual mesh with zero lag.
@@ -102,7 +111,8 @@ fn update_orbit_camera(
         orbit.target = Vec3::new(pos.x, pos.z, pos.y);
     }
 
-    // Right-click or middle-click drag to orbit.
+    // Right-click or middle-click drag to orbit — disabled under `locked_iso`.
+    #[cfg(not(feature = "locked_iso"))]
     if buttons.pressed(MouseButton::Right) || buttons.pressed(MouseButton::Middle) {
         orbit.yaw -= motion.delta.x * orbit.orbit_speed;
         orbit.pitch = (orbit.pitch + motion.delta.y * orbit.orbit_speed)

--- a/crates/client/src/plugins/terrain/chunk.rs
+++ b/crates/client/src/plugins/terrain/chunk.rs
@@ -223,7 +223,7 @@ fn stitch_row(indices: &mut Vec<u32>, vps: usize, vy_edge: usize, is_south: bool
     // For each even pair (k, k+2) on the edge, emit 3 stitching triangles
     // that merge via the interior neighbours.
     let mut k = 0u32;
-    while k + 2 <= vps - 1 {
+    while k + 2 < vps {
         let e0 = vy_e     * vps + k;
         let e2 = vy_e     * vps + k + 2;
         let m0 = vy_inner * vps + k;
@@ -263,7 +263,7 @@ fn stitch_col(indices: &mut Vec<u32>, vps: usize, vx_edge: usize, is_east: bool)
     let vx_inner = if is_east { vx_e - 1 } else { vx_e + 1 };
 
     let mut k = 0u32;
-    while k + 2 <= vps - 1 {
+    while k + 2 < vps {
         let e0 = k       * vps + vx_e;
         let e2 = (k + 2) * vps + vx_e;
         let m0 = k       * vps + vx_inner;

--- a/docs/systems/rendering.md
+++ b/docs/systems/rendering.md
@@ -18,11 +18,19 @@ The client runs in two modes:
 
 | Control | Action |
 |---|---|
-| Right-click drag | Orbit (yaw + pitch) |
-| Middle-click drag | Orbit (yaw + pitch) |
+| Right-click drag | Orbit (yaw + pitch) — **disabled when `locked_iso` is enabled** |
+| Middle-click drag | Orbit (yaw + pitch) — **disabled when `locked_iso` is enabled** |
 | Scroll wheel | Zoom in/out |
 
 Orbit state (yaw, pitch, distance, target) lives in `OrbitCamera`. The Bevy `Transform` is recomputed from those values every frame. Input is read from `AccumulatedMouseMotion` and `AccumulatedMouseScroll` resources (Bevy 0.18 input API).
+
+### `locked_iso` feature flag
+
+Cargo feature `locked_iso` on the `fellytip-client` crate locks the camera to a fixed-orientation dimetric isometric view — `yaw = ISO_YAW (45°)`, `pitch = ISO_PITCH (≈35.264°, atan(1/√2))`. Drag handlers are compiled out; only scroll zoom remains. This is the intended mode for the billboard-sprite art pipeline (see issue #13). Default builds keep the orbit handlers so top-down debugging via drag still works.
+
+```bash
+cargo run -p fellytip-client --features locked_iso
+```
 
 ## Lighting (`crates/client/src/plugins/scene_lighting.rs`)
 


### PR DESCRIPTION
## Summary
- Adds `locked_iso` cargo feature on `fellytip-client`. When enabled, right/middle-click drag-to-orbit is compiled out — only scroll-wheel zoom remains. Yaw/pitch are pinned to dimetric iso via two new `pub const`s (`ISO_YAW = 45°`, `ISO_PITCH = atan(1/√2)`) so the upcoming billboard-sprite renderer can reuse them.
- Default builds are unchanged — orbit drag is still live for top-down debugging.
- Fixes two pre-existing `clippy::int_plus_one` errors in `terrain/chunk.rs` that were already blocking `cargo clippy -- -D warnings` on master.

Closes #15. Parent tracker: #13.

## Known upstream breakage (not introduced here)
`cargo build -p fellytip-client` on current master fails with two pre-existing errors unrelated to the camera:
- `crates/client/src/main.rs:85` — `RemotePlugin::register_method` → renamed to `with_method` in the newer bevy_remote API.
- `crates/client/src/plugins/map.rs:11` — `bevy::render::render_asset::RenderAssetUsages` is private → should use `bevy_asset::render_asset::RenderAssetUsages`.

Both are bevy 0.18 API drifts from a recent refactor. Filing/fixing them is out of scope for #15; flagging so reviewers know CI red on this branch ≠ my change.

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — all green (includes 4 new tests carried in from the terrain-clearance merge)
- [x] `cargo build -p fellytip-client` (no features) — only the two pre-existing upstream errors above
- [x] `cargo clippy -p fellytip-client --features locked_iso -- -D warnings` — clean
- [ ] Manual smoke: run client with `--features locked_iso`, confirm right/middle drag does not rotate, scroll still zooms