### PR TITLE
feat(tools): sprite_gen skeleton with mock backend (#17)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -461,7 +467,7 @@ dependencies = [
  "downcast-rs 2.0.2",
  "either",
  "petgraph",
- "ron",
+ "ron 0.12.1",
  "serde",
  "smallvec",
  "thiserror 2.0.18",
@@ -558,7 +564,7 @@ dependencies = [
  "futures-lite",
  "futures-util",
  "js-sys",
- "ron",
+ "ron 0.12.1",
  "serde",
  "stackfuture",
  "thiserror 2.0.18",
@@ -930,7 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f37fb52655d0439656ca0a1db027d46926e463c81d893d4b1639668e5d7f1c1"
 dependencies = [
  "async-lock",
- "base64",
+ "base64 0.22.1",
  "bevy_animation",
  "bevy_app",
  "bevy_asset",
@@ -1445,7 +1451,7 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "derive_more",
- "ron",
+ "ron 0.12.1",
  "serde",
  "thiserror 2.0.18",
  "uuid",
@@ -3002,6 +3008,7 @@ dependencies = [
  "serde_json",
  "smol_str 0.3.6",
  "thiserror 2.0.18",
+ "toml",
  "tracing",
  "uuid",
 ]
@@ -4021,7 +4028,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -6022,7 +6029,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -6080,6 +6087,18 @@ checksum = "e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1"
 dependencies = [
  "cpal",
  "lewton",
+]
+
+[[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.11.0",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -6649,6 +6668,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sprite_gen"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "fellytip-shared",
+ "image",
+ "ron 0.8.1",
+ "serde",
+ "smol_str 0.3.6",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "sqlx"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6667,7 +6701,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "crc",
  "crossbeam-queue",
@@ -6740,7 +6774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.11.0",
  "byteorder",
  "bytes",
@@ -6782,7 +6816,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.11.0",
  "byteorder",
  "crc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "tools/combat_sim",
     "tools/world_gen",
     "tools/ralph",
+    "tools/sprite_gen",
     "tools/worldwatch",
 ]
 
@@ -32,6 +33,8 @@ proptest-derive     = "0.4"
 bevy_egui           = { version = "0.39", default-features = false }
 bevy-inspector-egui = { version = "0.36", default-features = false }
 reqwest             = { version = "0.12", features = ["json", "blocking"] }
+image               = { version = "0.25", default-features = false, features = ["png"] }
+ron                 = "0.8"
 fellytip-shared     = { path = "crates/shared" }
 
 [profile.dev.package."*"]

--- a/tools/sprite_gen/Cargo.toml
+++ b/tools/sprite_gen/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name    = "sprite_gen"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+fellytip-shared = { workspace = true }
+anyhow          = { workspace = true }
+thiserror       = { workspace = true }
+tracing         = { workspace = true }
+serde           = { workspace = true }
+smol_str        = { workspace = true }
+image           = { workspace = true }
+ron             = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/tools/sprite_gen/src/assembler.rs
+++ b/tools/sprite_gen/src/assembler.rs
@@ -1,0 +1,96 @@
+//! Stitch per-frame images into one atlas PNG.
+
+use crate::generator::{FrameRequest, SpriteGenerator};
+use crate::layout::AtlasLayout;
+use anyhow::Context;
+use fellytip_shared::bestiary::BestiaryEntry;
+use image::RgbaImage;
+
+/// Run the generator for every (animation × direction × frame) cell and copy
+/// each result into the correct atlas slot.  Pure in-memory; no file I/O.
+pub fn assemble_atlas(
+    generator: &dyn SpriteGenerator,
+    entry: &BestiaryEntry,
+    layout: &AtlasLayout,
+) -> anyhow::Result<RgbaImage> {
+    let mut atlas = RgbaImage::new(layout.image_width(), layout.image_height());
+    for slot in &layout.animations {
+        for dir in 0..layout.directions {
+            let row = slot.row_start + dir;
+            for frame in 0..slot.frames {
+                let img = generator
+                    .generate(FrameRequest {
+                        entity_id: entry.id.as_str(),
+                        animation: slot.name.as_str(),
+                        direction: dir,
+                        frame,
+                        tile_size: layout.tile_size,
+                    })
+                    .with_context(|| {
+                        format!(
+                            "generating {}/{}/dir{}/frame{}",
+                            entry.id, slot.name, dir, frame
+                        )
+                    })?;
+                let (ox, oy) = layout.cell_origin(row, frame);
+                copy_tile(&mut atlas, &img, ox, oy);
+            }
+        }
+    }
+    Ok(atlas)
+}
+
+fn copy_tile(dst: &mut RgbaImage, src: &RgbaImage, ox: u32, oy: u32) {
+    for y in 0..src.height() {
+        for x in 0..src.width() {
+            dst.put_pixel(ox + x, oy + y, *src.get_pixel(x, y));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generator::MockGenerator;
+    use fellytip_shared::bestiary::{AnimationDef, BestiaryEntry};
+
+    fn small_entry() -> BestiaryEntry {
+        BestiaryEntry {
+            id: "tiny".into(),
+            display_name: "Tiny".into(),
+            directions: 4,
+            ai_prompt_base: "p".into(),
+            ai_style: "s".into(),
+            palette_seed: "g".into(),
+            animations: vec![AnimationDef {
+                name: "idle".into(),
+                frames: 2,
+                fps: 1,
+            }],
+        }
+    }
+
+    #[test]
+    fn atlas_dimensions_match_layout() {
+        let e = small_entry();
+        let l = AtlasLayout::from_entry(&e);
+        let atlas = assemble_atlas(&MockGenerator, &e, &l).unwrap();
+        assert_eq!(atlas.width(), l.image_width());
+        assert_eq!(atlas.height(), l.image_height());
+    }
+
+    #[test]
+    fn different_directions_produce_different_pixels() {
+        let e = small_entry();
+        let l = AtlasLayout::from_entry(&e);
+        let atlas = assemble_atlas(&MockGenerator, &e, &l).unwrap();
+        // Sample the top-left pixel of the dir=0 tile and the dir=1 tile.
+        let (x0, y0) = l.cell_origin(0, 0); // anim 0, dir 0, frame 0
+        let (x1, y1) = l.cell_origin(1, 0); // anim 0, dir 1, frame 0
+        assert_ne!(
+            atlas.get_pixel(x0, y0),
+            atlas.get_pixel(x1, y1),
+            "dir 0 and dir 1 should produce different colors"
+        );
+    }
+}

--- a/tools/sprite_gen/src/generator.rs
+++ b/tools/sprite_gen/src/generator.rs
@@ -1,0 +1,123 @@
+//! Image-source abstraction for sprite frames.
+//!
+//! `#18` wires a real AI backend; this file ships a deterministic mock so the
+//! end-to-end pipeline (layout → image → PNG + RON) can be exercised offline.
+
+use image::{Rgba, RgbaImage};
+
+/// Parameters describing a single frame request.
+#[derive(Debug, Clone, Copy)]
+pub struct FrameRequest<'a> {
+    pub entity_id: &'a str,
+    pub animation: &'a str,
+    pub direction: u32,
+    pub frame: u32,
+    pub tile_size: u32,
+}
+
+pub trait SpriteGenerator {
+    /// Produce a single frame as an RGBA tile_size × tile_size image.
+    fn generate(&self, req: FrameRequest<'_>) -> anyhow::Result<RgbaImage>;
+
+    /// Prompt that would be sent to the backend for this frame.  Used by
+    /// `--dry-run` so CI and reviewers can eyeball the prompts without cost.
+    fn prompt_for(&self, _req: FrameRequest<'_>, base_prompt: &str, style: &str) -> String {
+        format!("{base_prompt} | {style}")
+    }
+}
+
+/// Deterministic placeholder generator — emits a solid-color frame keyed by
+/// `(entity_id, direction, frame)` with a small progress stripe at the bottom
+/// so animations aren't visually identical.  Fast, no network, no secrets.
+pub struct MockGenerator;
+
+impl SpriteGenerator for MockGenerator {
+    fn generate(&self, req: FrameRequest<'_>) -> anyhow::Result<RgbaImage> {
+        let [r, g, b] = mock_color(req.entity_id, req.direction);
+        let mut img = RgbaImage::from_pixel(req.tile_size, req.tile_size, Rgba([r, g, b, 255]));
+
+        // Progress stripe: proportional to `frame` (darker = earlier).
+        let stripe_h = (req.tile_size / 8).max(2);
+        let progress = req.frame.saturating_add(1) as f32
+            / (req.frame.saturating_add(2)) as f32; // 1/2, 2/3, 3/4, ...
+        let filled = (req.tile_size as f32 * progress) as u32;
+        for y in (req.tile_size - stripe_h)..req.tile_size {
+            for x in 0..filled.min(req.tile_size) {
+                img.put_pixel(x, y, Rgba([255, 255, 255, 255]));
+            }
+        }
+        Ok(img)
+    }
+
+    fn prompt_for(&self, req: FrameRequest<'_>, base_prompt: &str, style: &str) -> String {
+        // Dry-run output matches what a real backend would receive.
+        format!(
+            "{base_prompt}, facing direction {}/{max}, frame {} of anim `{}` | style: {style}",
+            req.direction,
+            req.frame,
+            req.animation,
+            max = 7,
+        )
+    }
+}
+
+/// FNV-1a hash → RGB color.  Deterministic, no external randomness.
+fn mock_color(entity_id: &str, direction: u32) -> [u8; 3] {
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64  = 0x100000001b3;
+    let mut h: u64 = FNV_OFFSET;
+    for b in entity_id.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(FNV_PRIME);
+    }
+    h ^= direction as u64;
+    h = h.wrapping_mul(FNV_PRIME);
+
+    [
+        ((h >> 16) & 0xff) as u8,
+        ((h >> 8)  & 0xff) as u8,
+        ( h        & 0xff) as u8,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_colors_are_stable() {
+        let a = mock_color("goblin_scout", 0);
+        let b = mock_color("goblin_scout", 0);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn mock_colors_differ_by_direction() {
+        let a = mock_color("goblin_scout", 0);
+        let b = mock_color("goblin_scout", 1);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn mock_colors_differ_by_entity() {
+        let a = mock_color("goblin_scout", 0);
+        let b = mock_color("orc_grunt", 0);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn mock_generate_produces_expected_dimensions() {
+        let g = MockGenerator;
+        let img = g
+            .generate(FrameRequest {
+                entity_id: "x",
+                animation: "idle",
+                direction: 0,
+                frame: 0,
+                tile_size: 64,
+            })
+            .unwrap();
+        assert_eq!(img.width(), 64);
+        assert_eq!(img.height(), 64);
+    }
+}

--- a/tools/sprite_gen/src/incremental.rs
+++ b/tools/sprite_gen/src/incremental.rs
@@ -1,0 +1,63 @@
+//! `--incremental` skip logic — avoid regenerating entities whose atlas is
+//! already newer than the bestiary source.
+
+use std::path::Path;
+use std::time::SystemTime;
+
+/// Returns `true` iff `output_png` exists and its mtime is strictly newer
+/// than `bestiary_toml`'s mtime.
+pub fn can_skip(bestiary_toml: &Path, output_png: &Path) -> bool {
+    let Ok(bm) = mtime(bestiary_toml) else { return false; };
+    let Ok(om) = mtime(output_png) else { return false; };
+    om > bm
+}
+
+fn mtime(p: &Path) -> std::io::Result<SystemTime> {
+    std::fs::metadata(p)?.modified()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+    use std::thread;
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    fn touch(path: &Path, content: &str) {
+        let mut f = fs::File::create(path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn missing_output_is_not_skipped() {
+        let dir = tempdir().unwrap();
+        let b = dir.path().join("bestiary.toml");
+        let o = dir.path().join("out.png");
+        touch(&b, "");
+        assert!(!can_skip(&b, &o));
+    }
+
+    #[test]
+    fn older_output_is_not_skipped() {
+        let dir = tempdir().unwrap();
+        let b = dir.path().join("bestiary.toml");
+        let o = dir.path().join("out.png");
+        touch(&o, "");
+        thread::sleep(Duration::from_millis(20));
+        touch(&b, "");
+        assert!(!can_skip(&b, &o));
+    }
+
+    #[test]
+    fn newer_output_is_skipped() {
+        let dir = tempdir().unwrap();
+        let b = dir.path().join("bestiary.toml");
+        let o = dir.path().join("out.png");
+        touch(&b, "");
+        thread::sleep(Duration::from_millis(20));
+        touch(&o, "");
+        assert!(can_skip(&b, &o));
+    }
+}

--- a/tools/sprite_gen/src/layout.rs
+++ b/tools/sprite_gen/src/layout.rs
@@ -1,0 +1,137 @@
+//! Atlas layout math — pure, deterministic, no I/O.
+//!
+//! A single entity's atlas is a grid of `(animations × directions)` rows and
+//! `max_frames` columns.  Row-major:
+//!
+//!   row(anim_index, dir) = anim_index * directions + dir
+//!   col(frame)           = frame
+//!
+//! For animations shorter than `max_frames` the trailing cells are unused
+//! (transparent).  This wastes a few pixels but keeps one PNG per entity and
+//! lets the billboard renderer use a single `TextureAtlasLayout::from_grid`.
+
+use fellytip_shared::bestiary::BestiaryEntry;
+
+/// Size in pixels of one atlas cell (per frame image).
+pub const TILE_SIZE: u32 = 64;
+
+/// Layout of one entity's atlas.  Pure data derived from a [`BestiaryEntry`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AtlasLayout {
+    pub tile_size: u32,
+    pub columns: u32,
+    pub rows: u32,
+    pub directions: u32,
+    pub animations: Vec<AnimationSlot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnimationSlot {
+    pub name: smol_str::SmolStr,
+    /// First row used by this animation (direction 0 sits at `row_start`,
+    /// direction `d` at `row_start + d`).
+    pub row_start: u32,
+    pub frames: u32,
+    pub fps: u32,
+}
+
+impl AtlasLayout {
+    pub fn from_entry(entry: &BestiaryEntry) -> Self {
+        let directions = entry.directions as u32;
+        let columns = entry
+            .animations
+            .iter()
+            .map(|a| a.frames as u32)
+            .max()
+            .unwrap_or(1);
+
+        let mut animations = Vec::with_capacity(entry.animations.len());
+        let mut cursor = 0u32;
+        for a in &entry.animations {
+            animations.push(AnimationSlot {
+                name: a.name.clone(),
+                row_start: cursor,
+                frames: a.frames as u32,
+                fps: a.fps as u32,
+            });
+            cursor += directions;
+        }
+
+        AtlasLayout {
+            tile_size: TILE_SIZE,
+            columns,
+            rows: cursor,
+            directions,
+            animations,
+        }
+    }
+
+    pub fn image_width(&self) -> u32 {
+        self.columns * self.tile_size
+    }
+
+    pub fn image_height(&self) -> u32 {
+        self.rows * self.tile_size
+    }
+
+    /// Pixel origin for the cell at `(row, col)`.
+    pub fn cell_origin(&self, row: u32, col: u32) -> (u32, u32) {
+        (col * self.tile_size, row * self.tile_size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fellytip_shared::bestiary::AnimationDef;
+
+    fn entry(directions: u8, frames: &[u16]) -> BestiaryEntry {
+        BestiaryEntry {
+            id: "test".into(),
+            display_name: "Test".into(),
+            directions,
+            ai_prompt_base: "x".into(),
+            ai_style: "y".into(),
+            palette_seed: "z".into(),
+            animations: frames
+                .iter()
+                .enumerate()
+                .map(|(i, f)| AnimationDef {
+                    name: format!("a{i}").into(),
+                    frames: *f,
+                    fps: 10,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn row_col_math_matches_spec() {
+        // 8 directions, 3 animations with 4, 8, 5 frames.
+        let e = entry(8, &[4, 8, 5]);
+        let l = AtlasLayout::from_entry(&e);
+        assert_eq!(l.directions, 8);
+        assert_eq!(l.columns, 8);
+        assert_eq!(l.rows, 24); // 3 animations × 8 directions
+        assert_eq!(l.animations[0].row_start, 0);
+        assert_eq!(l.animations[1].row_start, 8);
+        assert_eq!(l.animations[2].row_start, 16);
+    }
+
+    #[test]
+    fn image_dimensions_are_grid_times_tile() {
+        let l = AtlasLayout::from_entry(&entry(4, &[3, 7]));
+        assert_eq!(l.tile_size, TILE_SIZE);
+        assert_eq!(l.columns, 7);
+        assert_eq!(l.rows, 8); // 2 animations × 4 directions
+        assert_eq!(l.image_width(), 7 * TILE_SIZE);
+        assert_eq!(l.image_height(), 8 * TILE_SIZE);
+    }
+
+    #[test]
+    fn cell_origin_is_top_left_corner() {
+        let l = AtlasLayout::from_entry(&entry(8, &[4]));
+        assert_eq!(l.cell_origin(0, 0), (0, 0));
+        assert_eq!(l.cell_origin(3, 2), (2 * TILE_SIZE, 3 * TILE_SIZE));
+    }
+}

--- a/tools/sprite_gen/src/lib.rs
+++ b/tools/sprite_gen/src/lib.rs
@@ -1,0 +1,8 @@
+//! Library surface for the sprite_gen CLI.  Exposed as a library so unit
+//! tests can exercise layout / assembler / manifest in isolation.
+
+pub mod assembler;
+pub mod generator;
+pub mod incremental;
+pub mod layout;
+pub mod manifest;

--- a/tools/sprite_gen/src/main.rs
+++ b/tools/sprite_gen/src/main.rs
@@ -1,0 +1,150 @@
+//! sprite_gen — generate 8-direction sprite atlases from `assets/bestiary.toml`.
+//!
+//! Usage:
+//!   cargo run -p sprite_gen -- [--all | --entity ID] [--output-dir DIR]
+//!                              [--bestiary PATH] [--dry-run] [--incremental]
+//!
+//! The default backend is the deterministic `MockGenerator`.  The real AI
+//! backend is wired up in a follow-up (issue #18).
+
+use anyhow::{anyhow, Context, Result};
+use fellytip_shared::bestiary::{load_bestiary, BestiaryEntry};
+use sprite_gen::{
+    assembler::assemble_atlas,
+    generator::{FrameRequest, MockGenerator, SpriteGenerator},
+    incremental::can_skip,
+    layout::AtlasLayout,
+    manifest::{to_ron, AtlasManifest},
+};
+use std::path::{Path, PathBuf};
+
+struct Args {
+    all: bool,
+    entity: Option<String>,
+    bestiary: PathBuf,
+    output_dir: PathBuf,
+    dry_run: bool,
+    incremental: bool,
+}
+
+fn main() -> Result<()> {
+    let args = parse_args()?;
+
+    let entries = load_bestiary(&args.bestiary)
+        .with_context(|| format!("loading bestiary {}", args.bestiary.display()))?;
+
+    let selected: Vec<&BestiaryEntry> = if let Some(id) = &args.entity {
+        let e = entries
+            .iter()
+            .find(|e| e.id.as_str() == id)
+            .ok_or_else(|| anyhow!("no such entity `{id}` in bestiary"))?;
+        vec![e]
+    } else if args.all {
+        entries.iter().collect()
+    } else {
+        return Err(anyhow!("must pass --all or --entity ID"));
+    };
+
+    if !args.dry_run {
+        std::fs::create_dir_all(&args.output_dir).with_context(|| {
+            format!("creating output dir {}", args.output_dir.display())
+        })?;
+    }
+
+    let generator = MockGenerator;
+    for entry in selected {
+        run_entity(entry, &generator, &args)?;
+    }
+    Ok(())
+}
+
+fn run_entity(
+    entry: &BestiaryEntry,
+    generator: &dyn SpriteGenerator,
+    args: &Args,
+) -> Result<()> {
+    let layout = AtlasLayout::from_entry(entry);
+    let png_path = args.output_dir.join(format!("{}.png", entry.id));
+    let ron_path = args.output_dir.join(format!("{}.ron", entry.id));
+
+    if args.dry_run {
+        print_prompts(entry, &layout, generator);
+        return Ok(());
+    }
+
+    if args.incremental && can_skip(&args.bestiary, &png_path) {
+        eprintln!("  {} — up to date, skipping", entry.id);
+        return Ok(());
+    }
+
+    eprintln!("  {} — generating {}×{} atlas", entry.id, layout.image_width(), layout.image_height());
+    let atlas = assemble_atlas(generator, entry, &layout)?;
+    atlas.save(&png_path).with_context(|| format!("writing {}", png_path.display()))?;
+
+    let manifest: AtlasManifest = (&layout).into();
+    let ron_text = to_ron(&manifest).context("serializing manifest to RON")?;
+    std::fs::write(&ron_path, ron_text)
+        .with_context(|| format!("writing {}", ron_path.display()))?;
+    Ok(())
+}
+
+fn print_prompts(entry: &BestiaryEntry, layout: &AtlasLayout, generator: &dyn SpriteGenerator) {
+    println!("{}:", entry.id);
+    for slot in &layout.animations {
+        for dir in 0..layout.directions {
+            for frame in 0..slot.frames {
+                let p = generator.prompt_for(
+                    FrameRequest {
+                        entity_id: entry.id.as_str(),
+                        animation: slot.name.as_str(),
+                        direction: dir,
+                        frame,
+                        tile_size: layout.tile_size,
+                    },
+                    &entry.ai_prompt_base,
+                    &entry.ai_style,
+                );
+                println!("  [{}/dir{}/f{}] {}", slot.name, dir, frame, p);
+            }
+        }
+    }
+}
+
+fn parse_args() -> Result<Args> {
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    let mut all = false;
+    let mut entity = None;
+    let mut bestiary = default_bestiary_path();
+    let mut output_dir = PathBuf::from("crates/client/assets/sprites");
+    let mut dry_run = false;
+    let mut incremental = false;
+
+    let mut i = 0;
+    while i < argv.len() {
+        match argv[i].as_str() {
+            "--all"         => { all = true; }
+            "--entity"      => { entity = Some(next(&argv, &mut i, "--entity")?); }
+            "--bestiary"    => { bestiary = PathBuf::from(next(&argv, &mut i, "--bestiary")?); }
+            "--output-dir"  => { output_dir = PathBuf::from(next(&argv, &mut i, "--output-dir")?); }
+            "--dry-run"     => { dry_run = true; }
+            "--incremental" => { incremental = true; }
+            other => return Err(anyhow!("unknown flag `{other}`")),
+        }
+        i += 1;
+    }
+
+    Ok(Args { all, entity, bestiary, output_dir, dry_run, incremental })
+}
+
+fn next(argv: &[String], i: &mut usize, flag: &str) -> Result<String> {
+    *i += 1;
+    argv.get(*i)
+        .cloned()
+        .ok_or_else(|| anyhow!("{flag} requires a value"))
+}
+
+fn default_bestiary_path() -> PathBuf {
+    // Repo root is two levels above this crate.
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../assets/bestiary.toml")
+}

--- a/tools/sprite_gen/src/manifest.rs
+++ b/tools/sprite_gen/src/manifest.rs
@@ -1,0 +1,101 @@
+//! RON sidecar describing the atlas grid for the billboard renderer.
+//!
+//! Bevy's `TextureAtlasLayout` isn't directly serializable, so we ship the
+//! grid parameters instead and let the renderer reconstruct the layout at
+//! runtime via `TextureAtlasLayout::from_grid`.
+
+use crate::layout::AtlasLayout;
+use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AtlasManifest {
+    pub tile_size: u32,
+    pub columns: u32,
+    pub rows: u32,
+    pub directions: u32,
+    pub animations: Vec<AnimationManifest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AnimationManifest {
+    pub name: SmolStr,
+    pub row_start: u32,
+    pub frames: u32,
+    pub fps: u32,
+}
+
+impl From<&AtlasLayout> for AtlasManifest {
+    fn from(l: &AtlasLayout) -> Self {
+        AtlasManifest {
+            tile_size: l.tile_size,
+            columns: l.columns,
+            rows: l.rows,
+            directions: l.directions,
+            animations: l
+                .animations
+                .iter()
+                .map(|a| AnimationManifest {
+                    name: a.name.clone(),
+                    row_start: a.row_start,
+                    frames: a.frames,
+                    fps: a.fps,
+                })
+                .collect(),
+        }
+    }
+}
+
+pub fn to_ron(m: &AtlasManifest) -> Result<String, ron::Error> {
+    ron::ser::to_string_pretty(m, ron::ser::PrettyConfig::default())
+}
+
+pub fn from_ron(s: &str) -> Result<AtlasManifest, ron::de::SpannedError> {
+    ron::from_str(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::layout::AtlasLayout;
+    use fellytip_shared::bestiary::{AnimationDef, BestiaryEntry};
+
+    fn entry() -> BestiaryEntry {
+        BestiaryEntry {
+            id: "goblin_scout".into(),
+            display_name: "Goblin Scout".into(),
+            directions: 8,
+            ai_prompt_base: "p".into(),
+            ai_style: "s".into(),
+            palette_seed: "g".into(),
+            animations: vec![
+                AnimationDef { name: "idle".into(),  frames: 4, fps: 4 },
+                AnimationDef { name: "walk".into(),  frames: 8, fps: 12 },
+            ],
+        }
+    }
+
+    #[test]
+    fn manifest_mirrors_layout() {
+        let e = entry();
+        let l = AtlasLayout::from_entry(&e);
+        let m = AtlasManifest::from(&l);
+        assert_eq!(m.tile_size, l.tile_size);
+        assert_eq!(m.columns, l.columns);
+        assert_eq!(m.rows, l.rows);
+        assert_eq!(m.directions, l.directions);
+        assert_eq!(m.animations.len(), 2);
+        assert_eq!(m.animations[0].row_start, 0);
+        assert_eq!(m.animations[1].row_start, 8);
+    }
+
+    #[test]
+    fn ron_roundtrip() {
+        let e = entry();
+        let l = AtlasLayout::from_entry(&e);
+        let m = AtlasManifest::from(&l);
+        let s = to_ron(&m).unwrap();
+        let back = from_ron(&s).unwrap();
+        assert_eq!(m, back);
+    }
+}


### PR DESCRIPTION
## Summary
New `tools/sprite_gen/` workspace binary that reads `assets/bestiary.toml` and emits one atlas PNG + one RON manifest per entity.

**Modules:**
- `layout` — atlas-grid math (rows = animations × directions, cols = max frames).
- `generator` — `SpriteGenerator` trait + `MockGenerator` (deterministic FNV-hashed color per `(entity_id, direction)` with a per-frame progress stripe).
- `assembler` — stitches per-frame images into one RGBA atlas.
- `manifest` — Bevy-friendly grid RON: \`{ tile_size, columns, rows, directions, animations: [{ name, row_start, frames, fps }] }\`, consumable by the billboard plugin (#19) via `TextureAtlasLayout::from_grid`.
- `incremental` — mtime-based skip (re-emit only if bestiary.toml is newer than atlas PNG).

**CLI:** `cargo run -p sprite_gen -- [--all | --entity ID] [--output-dir DIR] [--bestiary PATH] [--dry-run] [--incremental]`

Closes #17. Parent tracker: #13. Real AI backend follows in #18.

## Base branch
This PR is **stacked on #23** (`claude/issue-16-bestiary-schema`). Merge #23 first; then the base here will automatically retarget to `master`.

## Test plan
- [x] `cargo test -p sprite_gen` — 14 new tests passing
- [x] `cargo test -p fellytip-shared -p sprite_gen -p combat_sim -p world_gen` — all green
- [x] `cargo clippy -p sprite_gen -- -D warnings` — clean
- [x] End-to-end smoke: `cargo run -p sprite_gen -- --all --output-dir /tmp/...` → produces `goblin_scout.png` (512×2048) + `goblin_scout.ron`
- [x] `--dry-run` prints prompts for all (animation × direction × frame) cells
- [ ] `cargo test --workspace` still blocked by the two pre-existing upstream errors in `fellytip-client` (tracked in PR #22)