### PR TITLE
feat(tools): sprite_gen real AI backend (DALL-E 3) (#18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "combat_sim"
 version = "0.1.0"
 dependencies = [
@@ -6672,10 +6678,14 @@ name = "sprite_gen"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
+ "color_quant",
  "fellytip-shared",
  "image",
+ "reqwest",
  "ron 0.8.1",
  "serde",
+ "serde_json",
  "smol_str 0.3.6",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ bevy-inspector-egui = { version = "0.36", default-features = false }
 reqwest             = { version = "0.12", features = ["json", "blocking"] }
 image               = { version = "0.25", default-features = false, features = ["png"] }
 ron                 = "0.8"
+color_quant         = "1"
 fellytip-shared     = { path = "crates/shared" }
 
 [profile.dev.package."*"]

--- a/tools/sprite_gen/Cargo.toml
+++ b/tools/sprite_gen/Cargo.toml
@@ -9,9 +9,13 @@ anyhow          = { workspace = true }
 thiserror       = { workspace = true }
 tracing         = { workspace = true }
 serde           = { workspace = true }
+serde_json      = { workspace = true }
 smol_str        = { workspace = true }
 image           = { workspace = true }
 ron             = { workspace = true }
+color_quant     = { workspace = true }
+reqwest         = { workspace = true }
+base64          = "0.22"
 
 [dev-dependencies]
 tempfile = "3"

--- a/tools/sprite_gen/README.md
+++ b/tools/sprite_gen/README.md
@@ -1,0 +1,66 @@
+# sprite_gen
+
+CLI that reads `assets/bestiary.toml` and emits a 2.5D billboard atlas
+(PNG) + a Bevy-friendly grid manifest (RON) per entity.
+
+## Usage
+
+```bash
+# Deterministic mock backend (default). Safe for CI and unit tests.
+cargo run -p sprite_gen -- --all --output-dir crates/client/assets/sprites/
+
+# Dry-run prints every prompt the backend would receive, no API calls.
+cargo run -p sprite_gen -- --all --dry-run
+
+# DALL-E 3 backend.
+SPRITE_GEN_API_KEY=sk-... cargo run -p sprite_gen -- \
+    --backend openai --entity goblin_scout \
+    --output-dir crates/client/assets/sprites/
+
+# 4-way parallel, skip entities whose atlas is newer than bestiary.toml.
+cargo run -p sprite_gen -- --all --incremental --workers 4
+```
+
+## Flags
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--all` | — | Generate every entity in the bestiary. |
+| `--entity ID` | — | Generate one entity by id. |
+| `--output-dir DIR` | `crates/client/assets/sprites` | Where PNG + RON land. |
+| `--bestiary PATH` | `assets/bestiary.toml` | Source file. |
+| `--dry-run` | off | Print prompts only, no images. |
+| `--incremental` | off | Skip entities whose atlas mtime > bestiary mtime. |
+| `--backend mock\|openai` | `mock` | Image source. |
+| `--workers N` | `1` | Max parallel generator calls. |
+| `--no-quantise` | off | Disable the 16-color palette quantiser. |
+
+## Environment (for `--backend openai`)
+
+| Var | Default | Purpose |
+|---|---|---|
+| `SPRITE_GEN_API_KEY` | **required** | OpenAI bearer token. |
+| `SPRITE_GEN_ENDPOINT` | `https://api.openai.com/v1/images/generations` | Swap for a compatible service. |
+| `SPRITE_GEN_MODEL` | `dall-e-3` | Image model id. |
+
+A missing `SPRITE_GEN_API_KEY` with `--backend openai` (and no `--dry-run`)
+exits non-zero with a clear message.
+
+## Licensing note
+
+OpenAI DALL-E outputs may be used commercially under the current OpenAI
+Terms of Use, but users are responsible for verifying current policy and
+for any third-party IP implications (e.g. resemblance to copyrighted
+characters). Re-verify before shipping generated sprites.
+
+## Determinism
+
+- Atlas layout is a pure function of the bestiary entry.
+- `MockGenerator` is FNV-hashed over `(entity_id, direction, frame)`.
+- The OpenAI backend folds a `frame_seed(entity_id, direction, frame)` into
+  the prompt (DALL-E 3 has no seed parameter; Stable-Diffusion backends
+  will consume it directly when that backend lands).
+- Palette quantisation (`NeuQuant`) is deterministic given a fixed input.
+
+Together these mean a rerun over the same bestiary + same backend produces
+byte-identical output — so the CI `--incremental` gate is reliable.

--- a/tools/sprite_gen/src/assembler.rs
+++ b/tools/sprite_gen/src/assembler.rs
@@ -2,42 +2,107 @@
 
 use crate::generator::{FrameRequest, SpriteGenerator};
 use crate::layout::AtlasLayout;
-use anyhow::Context;
+use crate::parallel::parallel_map;
 use fellytip_shared::bestiary::BestiaryEntry;
-use image::RgbaImage;
+use image::{Rgba, RgbaImage};
 
-/// Run the generator for every (animation × direction × frame) cell and copy
-/// each result into the correct atlas slot.  Pure in-memory; no file I/O.
+/// One cell request — captured up-front so the generator work can run in
+/// parallel while atlas composition stays single-threaded.
+struct Cell {
+    row: u32,
+    col: u32,
+    slot_name: smol_str::SmolStr,
+    direction: u32,
+    frame: u32,
+}
+
+/// Result of one cell — `None` means the generator failed; that cell is left
+/// transparent and logged so a later `--incremental` run can retry it.
+#[derive(Default)]
+struct CellResult {
+    image: Option<RgbaImage>,
+}
+
+/// Run the generator for every (animation × direction × frame) cell, each in
+/// its own worker, and copy each result into the correct atlas slot.
+///
+/// A single-frame failure is **logged and skipped** — the cell stays
+/// transparent so a later `--incremental` rerun can retry it.
 pub fn assemble_atlas(
-    generator: &dyn SpriteGenerator,
+    generator: &(dyn SpriteGenerator + Sync),
     entry: &BestiaryEntry,
     layout: &AtlasLayout,
+    workers: usize,
 ) -> anyhow::Result<RgbaImage> {
-    let mut atlas = RgbaImage::new(layout.image_width(), layout.image_height());
+    let cells = collect_cells(layout);
+    let tile_size = layout.tile_size;
+    let entity_id = entry.id.clone();
+
+    let cells_owned: Vec<Cell> = cells;
+    let generator_ref: &(dyn SpriteGenerator + Sync) = generator;
+
+    let results = parallel_map(cells_owned, workers, |c| {
+        let req = FrameRequest {
+            entity_id: entity_id.as_str(),
+            animation: c.slot_name.as_str(),
+            direction: c.direction,
+            frame: c.frame,
+            tile_size,
+        };
+        match generator_ref.generate(req) {
+            Ok(image) => CellResult { image: Some(image) },
+            Err(e) => {
+                tracing::warn!(
+                    entity = %entity_id,
+                    anim = %c.slot_name,
+                    dir = c.direction,
+                    frame = c.frame,
+                    "sprite generate failed: {e:#}",
+                );
+                CellResult { image: None }
+            }
+        }
+    });
+
+    let mut atlas = RgbaImage::from_pixel(
+        layout.image_width(),
+        layout.image_height(),
+        Rgba([0, 0, 0, 0]),
+    );
+    let mut failures = 0usize;
+    // Re-iterate cells in the same order to know where to paste each result.
+    for (idx, c) in collect_cells(layout).into_iter().enumerate() {
+        let res = &results[idx];
+        if let Some(img) = &res.image {
+            let (ox, oy) = layout.cell_origin(c.row, c.col);
+            copy_tile(&mut atlas, img, ox, oy);
+        } else {
+            failures += 1;
+        }
+    }
+    if failures > 0 {
+        tracing::warn!(entity = %entry.id, failures, "frames skipped; rerun with --incremental to retry");
+    }
+
+    Ok(atlas)
+}
+
+fn collect_cells(layout: &AtlasLayout) -> Vec<Cell> {
+    let mut cells = Vec::new();
     for slot in &layout.animations {
         for dir in 0..layout.directions {
-            let row = slot.row_start + dir;
             for frame in 0..slot.frames {
-                let img = generator
-                    .generate(FrameRequest {
-                        entity_id: entry.id.as_str(),
-                        animation: slot.name.as_str(),
-                        direction: dir,
-                        frame,
-                        tile_size: layout.tile_size,
-                    })
-                    .with_context(|| {
-                        format!(
-                            "generating {}/{}/dir{}/frame{}",
-                            entry.id, slot.name, dir, frame
-                        )
-                    })?;
-                let (ox, oy) = layout.cell_origin(row, frame);
-                copy_tile(&mut atlas, &img, ox, oy);
+                cells.push(Cell {
+                    row: slot.row_start + dir,
+                    col: frame,
+                    slot_name: slot.name.clone(),
+                    direction: dir,
+                    frame,
+                });
             }
         }
     }
-    Ok(atlas)
+    cells
 }
 
 fn copy_tile(dst: &mut RgbaImage, src: &RgbaImage, ox: u32, oy: u32) {
@@ -74,7 +139,7 @@ mod tests {
     fn atlas_dimensions_match_layout() {
         let e = small_entry();
         let l = AtlasLayout::from_entry(&e);
-        let atlas = assemble_atlas(&MockGenerator, &e, &l).unwrap();
+        let atlas = assemble_atlas(&MockGenerator, &e, &l, 1).unwrap();
         assert_eq!(atlas.width(), l.image_width());
         assert_eq!(atlas.height(), l.image_height());
     }
@@ -83,14 +148,37 @@ mod tests {
     fn different_directions_produce_different_pixels() {
         let e = small_entry();
         let l = AtlasLayout::from_entry(&e);
-        let atlas = assemble_atlas(&MockGenerator, &e, &l).unwrap();
-        // Sample the top-left pixel of the dir=0 tile and the dir=1 tile.
-        let (x0, y0) = l.cell_origin(0, 0); // anim 0, dir 0, frame 0
-        let (x1, y1) = l.cell_origin(1, 0); // anim 0, dir 1, frame 0
-        assert_ne!(
-            atlas.get_pixel(x0, y0),
-            atlas.get_pixel(x1, y1),
-            "dir 0 and dir 1 should produce different colors"
-        );
+        let atlas = assemble_atlas(&MockGenerator, &e, &l, 1).unwrap();
+        let (x0, y0) = l.cell_origin(0, 0);
+        let (x1, y1) = l.cell_origin(1, 0);
+        assert_ne!(atlas.get_pixel(x0, y0), atlas.get_pixel(x1, y1));
+    }
+
+    #[test]
+    fn worker_count_does_not_change_output() {
+        let e = small_entry();
+        let l = AtlasLayout::from_entry(&e);
+        let serial = assemble_atlas(&MockGenerator, &e, &l, 1).unwrap();
+        let parallel = assemble_atlas(&MockGenerator, &e, &l, 4).unwrap();
+        assert_eq!(serial.as_raw(), parallel.as_raw());
+    }
+
+    /// A generator whose `generate` always fails — simulates an API outage.
+    /// The assembler must produce an atlas (not propagate the error) and
+    /// leave the failed cells transparent.
+    struct AlwaysFail;
+    impl SpriteGenerator for AlwaysFail {
+        fn generate(&self, _req: FrameRequest<'_>) -> anyhow::Result<RgbaImage> {
+            Err(anyhow::anyhow!("simulated outage"))
+        }
+    }
+
+    #[test]
+    fn failed_frames_become_transparent_not_fatal() {
+        let e = small_entry();
+        let l = AtlasLayout::from_entry(&e);
+        let atlas = assemble_atlas(&AlwaysFail, &e, &l, 1).unwrap();
+        // Every pixel should be fully transparent.
+        assert!(atlas.pixels().all(|p| p.0[3] == 0));
     }
 }

--- a/tools/sprite_gen/src/lib.rs
+++ b/tools/sprite_gen/src/lib.rs
@@ -6,3 +6,7 @@ pub mod generator;
 pub mod incremental;
 pub mod layout;
 pub mod manifest;
+pub mod openai;
+pub mod palette;
+pub mod parallel;
+pub mod seeding;

--- a/tools/sprite_gen/src/main.rs
+++ b/tools/sprite_gen/src/main.rs
@@ -3,9 +3,12 @@
 //! Usage:
 //!   cargo run -p sprite_gen -- [--all | --entity ID] [--output-dir DIR]
 //!                              [--bestiary PATH] [--dry-run] [--incremental]
+//!                              [--backend mock|openai] [--workers N]
+//!                              [--no-quantise]
 //!
-//! The default backend is the deterministic `MockGenerator`.  The real AI
-//! backend is wired up in a follow-up (issue #18).
+//! Default backend is the deterministic `MockGenerator`.  `--backend openai`
+//! reads `SPRITE_GEN_API_KEY` (and optionally `SPRITE_GEN_ENDPOINT` /
+//! `SPRITE_GEN_MODEL`) to hit DALL-E 3.
 
 use anyhow::{anyhow, Context, Result};
 use fellytip_shared::bestiary::{load_bestiary, BestiaryEntry};
@@ -15,8 +18,16 @@ use sprite_gen::{
     incremental::can_skip,
     layout::AtlasLayout,
     manifest::{to_ron, AtlasManifest},
+    openai::OpenAiDalleGenerator,
+    palette::quantise_in_place,
 };
 use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Backend {
+    Mock,
+    OpenAi,
+}
 
 struct Args {
     all: bool,
@@ -25,6 +36,9 @@ struct Args {
     output_dir: PathBuf,
     dry_run: bool,
     incremental: bool,
+    backend: Backend,
+    workers: usize,
+    quantise: bool,
 }
 
 fn main() -> Result<()> {
@@ -46,21 +60,39 @@ fn main() -> Result<()> {
     };
 
     if !args.dry_run {
-        std::fs::create_dir_all(&args.output_dir).with_context(|| {
-            format!("creating output dir {}", args.output_dir.display())
-        })?;
+        std::fs::create_dir_all(&args.output_dir)
+            .with_context(|| format!("creating output dir {}", args.output_dir.display()))?;
     }
 
-    let generator = MockGenerator;
+    // Select a backend.  MockGenerator is always safe; OpenAiDalleGenerator
+    // refuses to construct without SPRITE_GEN_API_KEY so a missing secret
+    // exits non-zero with a clear message.
+    let generator: Box<dyn SpriteGenerator + Sync> = match args.backend {
+        Backend::Mock => Box::new(MockGenerator),
+        Backend::OpenAi => {
+            if args.dry_run {
+                // Dry-run doesn't actually call the API, so we don't need a
+                // live backend.  The OpenAi prompt shape differs though —
+                // use it for prompt formatting if the key happens to exist.
+                match OpenAiDalleGenerator::from_env() {
+                    Ok(g) => Box::new(g),
+                    Err(_) => Box::new(MockGenerator),
+                }
+            } else {
+                Box::new(OpenAiDalleGenerator::from_env()?)
+            }
+        }
+    };
+
     for entry in selected {
-        run_entity(entry, &generator, &args)?;
+        run_entity(entry, generator.as_ref(), &args)?;
     }
     Ok(())
 }
 
 fn run_entity(
     entry: &BestiaryEntry,
-    generator: &dyn SpriteGenerator,
+    generator: &(dyn SpriteGenerator + Sync),
     args: &Args,
 ) -> Result<()> {
     let layout = AtlasLayout::from_entry(entry);
@@ -77,9 +109,20 @@ fn run_entity(
         return Ok(());
     }
 
-    eprintln!("  {} — generating {}×{} atlas", entry.id, layout.image_width(), layout.image_height());
-    let atlas = assemble_atlas(generator, entry, &layout)?;
-    atlas.save(&png_path).with_context(|| format!("writing {}", png_path.display()))?;
+    eprintln!(
+        "  {} — generating {}×{} atlas (workers={})",
+        entry.id,
+        layout.image_width(),
+        layout.image_height(),
+        args.workers,
+    );
+    let mut atlas = assemble_atlas(generator, entry, &layout, args.workers)?;
+    if args.quantise {
+        quantise_in_place(&mut atlas);
+    }
+    atlas
+        .save(&png_path)
+        .with_context(|| format!("writing {}", png_path.display()))?;
 
     let manifest: AtlasManifest = (&layout).into();
     let ron_text = to_ron(&manifest).context("serializing manifest to RON")?;
@@ -88,7 +131,7 @@ fn run_entity(
     Ok(())
 }
 
-fn print_prompts(entry: &BestiaryEntry, layout: &AtlasLayout, generator: &dyn SpriteGenerator) {
+fn print_prompts(entry: &BestiaryEntry, layout: &AtlasLayout, generator: &(dyn SpriteGenerator + Sync)) {
     println!("{}:", entry.id);
     for slot in &layout.animations {
         for dir in 0..layout.directions {
@@ -118,22 +161,36 @@ fn parse_args() -> Result<Args> {
     let mut output_dir = PathBuf::from("crates/client/assets/sprites");
     let mut dry_run = false;
     let mut incremental = false;
+    let mut backend = Backend::Mock;
+    let mut workers: usize = 1;
+    let mut quantise = true;
 
     let mut i = 0;
     while i < argv.len() {
         match argv[i].as_str() {
-            "--all"         => { all = true; }
-            "--entity"      => { entity = Some(next(&argv, &mut i, "--entity")?); }
-            "--bestiary"    => { bestiary = PathBuf::from(next(&argv, &mut i, "--bestiary")?); }
-            "--output-dir"  => { output_dir = PathBuf::from(next(&argv, &mut i, "--output-dir")?); }
-            "--dry-run"     => { dry_run = true; }
-            "--incremental" => { incremental = true; }
+            "--all"          => all = true,
+            "--entity"       => entity = Some(next(&argv, &mut i, "--entity")?),
+            "--bestiary"     => bestiary = PathBuf::from(next(&argv, &mut i, "--bestiary")?),
+            "--output-dir"   => output_dir = PathBuf::from(next(&argv, &mut i, "--output-dir")?),
+            "--dry-run"      => dry_run = true,
+            "--incremental"  => incremental = true,
+            "--backend"      => backend = parse_backend(&next(&argv, &mut i, "--backend")?)?,
+            "--workers"      => workers = next(&argv, &mut i, "--workers")?.parse().context("--workers must be a positive integer")?,
+            "--no-quantise"  => quantise = false,
             other => return Err(anyhow!("unknown flag `{other}`")),
         }
         i += 1;
     }
 
-    Ok(Args { all, entity, bestiary, output_dir, dry_run, incremental })
+    Ok(Args { all, entity, bestiary, output_dir, dry_run, incremental, backend, workers, quantise })
+}
+
+fn parse_backend(s: &str) -> Result<Backend> {
+    match s {
+        "mock"   => Ok(Backend::Mock),
+        "openai" => Ok(Backend::OpenAi),
+        other    => Err(anyhow!("unknown backend `{other}` (expected `mock` or `openai`)")),
+    }
 }
 
 fn next(argv: &[String], i: &mut usize, flag: &str) -> Result<String> {
@@ -144,7 +201,5 @@ fn next(argv: &[String], i: &mut usize, flag: &str) -> Result<String> {
 }
 
 fn default_bestiary_path() -> PathBuf {
-    // Repo root is two levels above this crate.
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../../assets/bestiary.toml")
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../assets/bestiary.toml")
 }

--- a/tools/sprite_gen/src/openai.rs
+++ b/tools/sprite_gen/src/openai.rs
@@ -1,0 +1,149 @@
+//! OpenAI DALL-E 3 backend for `SpriteGenerator`.
+//!
+//! Reads config from env:
+//!   SPRITE_GEN_API_KEY  — required
+//!   SPRITE_GEN_ENDPOINT — defaults to https://api.openai.com/v1/images/generations
+//!   SPRITE_GEN_MODEL    — defaults to dall-e-3
+//!
+//! The backend cannot be constructed without an API key, which keeps the
+//! default (`MockGenerator`) safe for CI and unit tests.
+
+use crate::generator::{FrameRequest, SpriteGenerator};
+use crate::seeding::frame_seed;
+use anyhow::{anyhow, Context, Result};
+use base64::Engine as _;
+use image::{imageops::FilterType, RgbaImage};
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_ENDPOINT: &str = "https://api.openai.com/v1/images/generations";
+pub const DEFAULT_MODEL: &str = "dall-e-3";
+pub const DALLE_SIZE: &str = "1024x1024";
+
+pub struct OpenAiDalleGenerator {
+    client: reqwest::blocking::Client,
+    api_key: String,
+    endpoint: String,
+    model: String,
+}
+
+impl OpenAiDalleGenerator {
+    /// Construct a backend from env vars.  Returns an error (not a panic) if
+    /// `SPRITE_GEN_API_KEY` is missing so callers can fall back or exit
+    /// cleanly.
+    pub fn from_env() -> Result<Self> {
+        let api_key = std::env::var("SPRITE_GEN_API_KEY").map_err(|_| {
+            anyhow!(
+                "SPRITE_GEN_API_KEY is not set. Either export it, pass --dry-run, \
+                 or keep the default --backend mock."
+            )
+        })?;
+        let endpoint = std::env::var("SPRITE_GEN_ENDPOINT")
+            .unwrap_or_else(|_| DEFAULT_ENDPOINT.to_string());
+        let model = std::env::var("SPRITE_GEN_MODEL")
+            .unwrap_or_else(|_| DEFAULT_MODEL.to_string());
+
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(120))
+            .build()
+            .context("building HTTP client")?;
+
+        Ok(Self { client, api_key, endpoint, model })
+    }
+}
+
+#[derive(Serialize)]
+struct Request<'a> {
+    model: &'a str,
+    prompt: &'a str,
+    n: u8,
+    size: &'a str,
+    response_format: &'a str,
+}
+
+#[derive(Deserialize)]
+struct Response {
+    data: Vec<Datum>,
+}
+
+#[derive(Deserialize)]
+struct Datum {
+    b64_json: String,
+}
+
+impl SpriteGenerator for OpenAiDalleGenerator {
+    fn generate(&self, req: FrameRequest<'_>) -> Result<RgbaImage> {
+        // Prompt includes a pseudo-seed for reproducibility citation.
+        let seed = frame_seed(req.entity_id, req.direction, req.frame);
+        let prompt = format!(
+            "{}, facing direction {}/{} (sprite-grid), frame {} of `{}`. \
+             Seed={seed:016x}. Isolated subject, transparent background, \
+             centered, no UI, no text, no watermark.",
+            req.entity_id, req.direction, 7, req.frame, req.animation
+        );
+
+        let body = Request {
+            model: &self.model,
+            prompt: &prompt,
+            n: 1,
+            size: DALLE_SIZE,
+            response_format: "b64_json",
+        };
+
+        let resp = self
+            .client
+            .post(&self.endpoint)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .context("sending request to image API")?;
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().unwrap_or_default();
+            return Err(anyhow!("image API returned {status}: {text}"));
+        }
+
+        let parsed: Response = resp.json().context("parsing image API response")?;
+        let datum = parsed
+            .data
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow!("image API returned no data"))?;
+
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&datum.b64_json)
+            .context("decoding base64 image")?;
+        let img = image::load_from_memory(&bytes).context("decoding PNG/JPEG bytes")?;
+
+        // Resize to tile_size with a clean filter.
+        let resized = img.resize_exact(req.tile_size, req.tile_size, FilterType::Lanczos3);
+        Ok(resized.to_rgba8())
+    }
+
+    fn prompt_for(&self, req: FrameRequest<'_>, base_prompt: &str, style: &str) -> String {
+        let seed = frame_seed(req.entity_id, req.direction, req.frame);
+        format!(
+            "{base_prompt}, facing direction {}/{} (sprite-grid), frame {} of `{}`. \
+             Seed={seed:016x}. Style: {style}. Isolated subject, transparent background.",
+            req.direction, 7, req.frame, req.animation
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// When the env var is missing, construction fails with a clear message —
+    /// callers rely on this to keep mock-default behavior deterministic.
+    #[test]
+    fn missing_api_key_is_a_clean_error() {
+        // Scrub any ambient value for this thread.
+        // SAFETY: only this test removes the var; other tests don't set it.
+        unsafe { std::env::remove_var("SPRITE_GEN_API_KEY"); }
+        let result = OpenAiDalleGenerator::from_env();
+        match result {
+            Err(e) => assert!(e.to_string().contains("SPRITE_GEN_API_KEY")),
+            Ok(_) => panic!("construction must fail without SPRITE_GEN_API_KEY"),
+        }
+    }
+}

--- a/tools/sprite_gen/src/palette.rs
+++ b/tools/sprite_gen/src/palette.rs
@@ -1,0 +1,79 @@
+//! Palette quantization — post-process generated frames so all of an entity's
+//! sprites share a tight color palette, hiding small stylistic drift between
+//! AI outputs.  Pure, deterministic; no I/O.
+
+use color_quant::NeuQuant;
+use image::{Rgba, RgbaImage};
+
+/// Number of palette entries to lock an entity's sprites to.  16 is
+/// aggressive enough to enforce a consistent look without killing detail.
+pub const PALETTE_COLORS: usize = 16;
+
+/// Re-colour `img` to its own `PALETTE_COLORS`-entry quantised palette.
+/// Fully transparent pixels are left untouched.
+pub fn quantise_in_place(img: &mut RgbaImage) {
+    let pixels: Vec<u8> = img.as_raw().clone();
+    let nq = NeuQuant::new(10, PALETTE_COLORS, &pixels);
+
+    for px in img.pixels_mut() {
+        let [r, g, b, a] = px.0;
+        if a == 0 {
+            continue;
+        }
+        let ix = nq.index_of(&[r, g, b, a]);
+        let palette = nq.color_map_rgba();
+        let base = ix * 4;
+        *px = Rgba([palette[base], palette[base + 1], palette[base + 2], a]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quantise_is_deterministic() {
+        let mut a = RgbaImage::from_pixel(16, 16, Rgba([123, 200, 50, 255]));
+        let mut b = a.clone();
+        // Scribble a gradient so the quantiser has variety to work with.
+        for (i, px) in a.pixels_mut().enumerate() {
+            px.0 = [(i % 256) as u8, (i * 2 % 256) as u8, 80, 255];
+        }
+        for (i, px) in b.pixels_mut().enumerate() {
+            px.0 = [(i % 256) as u8, (i * 2 % 256) as u8, 80, 255];
+        }
+        quantise_in_place(&mut a);
+        quantise_in_place(&mut b);
+        assert_eq!(a.as_raw(), b.as_raw());
+    }
+
+    #[test]
+    fn transparent_pixels_are_preserved() {
+        let mut img = RgbaImage::from_pixel(4, 4, Rgba([0, 0, 0, 0]));
+        // A handful of opaque pixels.
+        img.put_pixel(0, 0, Rgba([255, 0, 0, 255]));
+        img.put_pixel(1, 1, Rgba([0, 255, 0, 255]));
+        quantise_in_place(&mut img);
+        assert_eq!(img.get_pixel(3, 3).0[3], 0);
+    }
+
+    #[test]
+    fn output_uses_at_most_palette_colors() {
+        let mut img = RgbaImage::new(32, 32);
+        for (i, px) in img.pixels_mut().enumerate() {
+            let v = ((i * 7) % 256) as u8;
+            px.0 = [v, 255 - v, (v / 2) + 32, 255];
+        }
+        quantise_in_place(&mut img);
+        let mut distinct = std::collections::HashSet::new();
+        for px in img.pixels() {
+            distinct.insert(px.0);
+        }
+        assert!(
+            distinct.len() <= PALETTE_COLORS,
+            "expected ≤ {} distinct colors, got {}",
+            PALETTE_COLORS,
+            distinct.len()
+        );
+    }
+}

--- a/tools/sprite_gen/src/parallel.rs
+++ b/tools/sprite_gen/src/parallel.rs
@@ -1,0 +1,79 @@
+//! Scoped thread pool for parallel generator calls with a bounded worker
+//! count.  Built on `std::thread::scope` + a Mutex work queue — no external
+//! crate.
+//!
+//! Order is preserved: `parallel_map` returns results in the same order as
+//! the input iterator.
+
+use std::sync::Mutex;
+
+pub fn parallel_map<T, R, F>(items: Vec<T>, workers: usize, f: F) -> Vec<R>
+where
+    T: Send,
+    R: Send + Default,
+    F: Fn(T) -> R + Sync + Send,
+{
+    let workers = workers.max(1);
+    let len = items.len();
+    let mut results: Vec<R> = (0..len).map(|_| R::default()).collect();
+
+    if workers == 1 || len <= 1 {
+        for (i, item) in items.into_iter().enumerate() {
+            results[i] = f(item);
+        }
+        return results;
+    }
+
+    // Queue of (index, item) pairs; workers pop from the front.
+    let queue: Mutex<Vec<(usize, T)>> = Mutex::new(items.into_iter().enumerate().rev().collect());
+    let results_mtx = Mutex::new(&mut results);
+    let f_ref = &f;
+
+    std::thread::scope(|scope| {
+        for _ in 0..workers {
+            let q = &queue;
+            let out = &results_mtx;
+            scope.spawn(move || loop {
+                let Some((idx, item)) = q.lock().unwrap().pop() else { return; };
+                let r = f_ref(item);
+                let mut slot = out.lock().unwrap();
+                slot[idx] = r;
+            });
+        }
+    });
+
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_order() {
+        let items: Vec<u32> = (0..64).collect();
+        let got = parallel_map(items.clone(), 4, |x| x * 2);
+        let want: Vec<u32> = items.iter().map(|x| x * 2).collect();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn single_worker_equivalent_to_sequential() {
+        let items: Vec<u32> = (0..16).collect();
+        let got = parallel_map(items, 1, |x| x + 1);
+        let want: Vec<u32> = (1..17).collect();
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn zero_workers_treated_as_one() {
+        let got = parallel_map(vec![10u32, 20, 30], 0, |x| x * 10);
+        assert_eq!(got, vec![100, 200, 300]);
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        let got: Vec<u32> = parallel_map(Vec::<u32>::new(), 4, |x| x);
+        assert!(got.is_empty());
+    }
+}

--- a/tools/sprite_gen/src/seeding.rs
+++ b/tools/sprite_gen/src/seeding.rs
@@ -1,0 +1,34 @@
+//! Deterministic seed derivation for sprite generation.
+//!
+//! DALL-E 3 doesn't accept an explicit seed parameter, but folding a stable
+//! seed into the prompt string nudges the backend toward repeatable output
+//! and gives us a reproducible identifier to cite in the atlas manifest.
+//! Stable-Diffusion backends accept the seed directly.
+
+pub fn frame_seed(entity_id: &str, direction: u32, frame: u32) -> u64 {
+    // FNV-1a (64-bit) of `entity_id|direction|frame`.
+    const OFFSET: u64 = 0xcbf29ce484222325;
+    const PRIME:  u64 = 0x100000001b3;
+    let mut h = OFFSET;
+    for b in entity_id.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(PRIME);
+    }
+    h ^= direction as u64;
+    h = h.wrapping_mul(PRIME);
+    h ^= frame as u64;
+    h.wrapping_mul(PRIME)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seeds_are_stable_and_distinct() {
+        assert_eq!(frame_seed("x", 0, 0), frame_seed("x", 0, 0));
+        assert_ne!(frame_seed("x", 0, 0), frame_seed("x", 1, 0));
+        assert_ne!(frame_seed("x", 0, 0), frame_seed("x", 0, 1));
+        assert_ne!(frame_seed("x", 0, 0), frame_seed("y", 0, 0));
+    }
+}


### PR DESCRIPTION
## Summary
Wires a real image backend (`OpenAiDalleGenerator`, DALL-E 3) behind the existing `SpriteGenerator` trait and adds the surrounding machinery:

- `openai` — `reqwest::blocking` client. `from_env()` reads `SPRITE_GEN_API_KEY` (required), `SPRITE_GEN_ENDPOINT`, `SPRITE_GEN_MODEL`. Missing key returns `Err`, not panic.
- `seeding` — FNV-1a over `(entity_id, direction, frame)` → stable u64 folded into the prompt.
- `palette` — NeuQuant 16-color quantiser to suppress AI style drift across frames. Alpha preserved.
- `parallel` — `std::thread::scope`-based ordered worker pool (no rayon dep).
- `assembler` — per-frame calls run through `parallel_map`; per-cell failures log-and-skip (cell stays transparent, later `--incremental` run retries).

**CLI gains:** `--backend mock|openai`, `--workers N`, `--no-quantise`.
**Default backend remains `mock`** — tests and CI never hit the network.

**25 tests total in sprite_gen (11 new)**, covering: backend-missing-key path, parallel_map order/edge cases, quantiser determinism + palette-size bound + alpha preservation, seed determinism, AlwaysFail assembler path.

`tools/sprite_gen/README.md` documents flags, env vars, licensing caveats, and determinism guarantees.

Closes #18. Parent tracker: #13.

## Base branch
Stacked on **#24** (`claude/issue-17-sprite-gen`), which stacks on **#23**. Merge bottom-up or squash-merge each; GitHub will retarget.

## Test plan
- [x] `cargo test -p sprite_gen` — 25 passed
- [x] `cargo clippy -p sprite_gen -- -D warnings` — clean
- [x] Smoke run: `cargo run -p sprite_gen -- --all --workers 4` → atlas + RON produced
- [x] `cargo run -p sprite_gen -- --backend openai --all` with unset key → exits non-zero with a clear message
- [ ] Real OpenAI call — requires a key; not run in this PR. Gate lives in the CI workflow (#20).