### PR TITLE
ci: auto-generate sprites on bestiary.toml changes (#20)

### DIFF
--- a/.github/workflows/sprites.yml
+++ b/.github/workflows/sprites.yml
@@ -1,0 +1,107 @@
+name: sprites
+
+# Regenerate sprite atlases whenever the bestiary or the sprite_gen tool
+# changes.  PRs run a mock-backend dry-run (no secrets needed) so reviewers
+# can see the intended prompts.  Pushes to master run the real backend
+# (guarded on SPRITE_GEN_API_KEY presence) and upload the resulting atlases
+# as an artifact for human review before they land as committed assets.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "assets/bestiary.toml"
+      - "tools/sprite_gen/**"
+      - ".github/workflows/sprites.yml"
+  pull_request:
+    paths:
+      - "assets/bestiary.toml"
+      - "tools/sprite_gen/**"
+      - ".github/workflows/sprites.yml"
+
+concurrency:
+  group: sprites-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # PR path: no secret required.  Proves the pipeline builds and that
+  # every bestiary entry produces a valid atlas with the mock backend.
+  dry-run:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Validate sprite_gen builds + tests
+        run: |
+          cargo test -p sprite_gen --locked
+
+      - name: Print all prompts (mock backend, no network)
+        run: |
+          cargo run -q -p sprite_gen --locked -- --all --dry-run
+
+      - name: Generate atlases with mock backend
+        run: |
+          cargo run -q -p sprite_gen --locked -- \
+            --all \
+            --output-dir crates/client/assets/sprites/
+
+      - name: Upload mock sprites for inspection
+        uses: actions/upload-artifact@v4
+        with:
+          name: sprites-mock-${{ github.sha }}
+          path: crates/client/assets/sprites/
+          if-no-files-found: error
+          retention-days: 7
+
+  # Post-merge: real backend when the API key is configured.  Job is
+  # skipped cleanly if the secret isn't set, so forks and early-stage
+  # repos don't see a red checkmark.
+  generate:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: sprite-gen
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check for API key
+        id: apikey
+        env:
+          SPRITE_GEN_API_KEY: ${{ secrets.SPRITE_GEN_API_KEY }}
+        run: |
+          if [ -z "${SPRITE_GEN_API_KEY}" ]; then
+            echo "No SPRITE_GEN_API_KEY secret set — skipping real generation."
+            echo "have_key=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "have_key=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate atlases (OpenAI backend, incremental)
+        if: steps.apikey.outputs.have_key == 'true'
+        env:
+          SPRITE_GEN_API_KEY: ${{ secrets.SPRITE_GEN_API_KEY }}
+          SPRITE_GEN_ENDPOINT: ${{ vars.SPRITE_GEN_ENDPOINT }}
+          SPRITE_GEN_MODEL: ${{ vars.SPRITE_GEN_MODEL }}
+        run: |
+          cargo run -q -p sprite_gen --locked --release -- \
+            --backend openai \
+            --all \
+            --incremental \
+            --workers 4 \
+            --output-dir crates/client/assets/sprites/
+
+      - name: Upload generated sprites
+        if: steps.apikey.outputs.have_key == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sprites-${{ github.sha }}
+          path: crates/client/assets/sprites/
+          if-no-files-found: error
+          retention-days: 30

--- a/tools/sprite_gen/README.md
+++ b/tools/sprite_gen/README.md
@@ -53,6 +53,21 @@ Terms of Use, but users are responsible for verifying current policy and
 for any third-party IP implications (e.g. resemblance to copyrighted
 characters). Re-verify before shipping generated sprites.
 
+## CI
+
+`.github/workflows/sprites.yml` runs on any change to `assets/bestiary.toml`
+or `tools/sprite_gen/**`:
+
+- **Pull requests** run `sprite_gen --all --dry-run` + a mock-backend
+  atlas generation; no secret required. The resulting atlases upload as
+  a `sprites-mock-<sha>` artifact so reviewers can see what the new
+  entries will produce.
+- **Pushes to `master`** run the real backend when the `SPRITE_GEN_API_KEY`
+  secret is configured on the `sprite-gen` environment, and upload the
+  resulting atlases as a `sprites-<sha>` artifact for human review before
+  they're committed as assets. If the secret isn't set, the job skips
+  cleanly rather than failing.
+
 ## Determinism
 
 - Atlas layout is a pure function of the bestiary entry.


### PR DESCRIPTION
## Summary

New workflow `.github/workflows/sprites.yml` that runs on any change to `assets/bestiary.toml` or `tools/sprite_gen/**`.

- **Pull requests** — runs `cargo test -p sprite_gen`, prints all prompts via `--dry-run`, and generates mock-backend atlases. Uploads as `sprites-mock-<sha>` artifact. **No secret required.**
- **Pushes to `master`** — if `SPRITE_GEN_API_KEY` is configured on the `sprite-gen` environment, runs the real OpenAI backend with `--incremental --workers 4 --release` and uploads the resulting atlases as `sprites-<sha>`. If the secret isn't set, the job **skips cleanly** rather than failing, so forks / early-stage repos stay green.

Generated atlases intentionally do **not** auto-commit — a human reviews the artifact before landing it as a committed asset.

README updated with a new CI section documenting both triggers.

Closes #20. Parent tracker: #13. Depends on #18.

## Base branch
Stacked on **#25** (`claude/issue-18-ai-backend`) → **#24** → **#23**. Will retarget to master as the stack merges.

## Test plan
- [x] Workflow YAML is syntactically valid (verified locally via `cargo run -p sprite_gen -- --all --dry-run` reproducing the PR-path command).
- [ ] CI dry-run job runs green on this PR once Actions kicks in (visible in the PR checks).
- [ ] Optional: configure `SPRITE_GEN_API_KEY` on the `sprite-gen` environment to activate the real-generation path post-merge.