### PR TITLE
feat: complete saving throw proficiency coverage for all 14 classes

### DIFF
--- a/crates/shared/src/combat/mod.rs
+++ b/crates/shared/src/combat/mod.rs
@@ -4,6 +4,6 @@ pub mod rules;
 pub mod spells;
 pub mod types;
 
-pub use rules::{hp_on_level_up, resolve_saving_throw, xp_to_next_level};
+pub use rules::{hp_on_level_up, resolve_saving_throw, roll_saving_throw, xp_to_next_level};
 pub use types::{hit_die_for_class, proficiency_bonus};
 pub use spells::{find_spell, SpellSlots, Spellbook, SPELLS};

--- a/crates/shared/src/components.rs
+++ b/crates/shared/src/components.rs
@@ -691,6 +691,68 @@ mod tests {
     }
 
     #[test]
+    fn saving_throw_proficiencies_paladin() {
+        let s = SavingThrowProficiencies::paladin();
+        assert!(s.wisdom);
+        assert!(s.charisma);
+        assert!(!s.strength);
+    }
+
+    #[test]
+    fn saving_throw_proficiencies_ranger() {
+        let s = SavingThrowProficiencies::ranger();
+        assert!(s.strength);
+        assert!(s.dexterity);
+        assert!(!s.constitution);
+    }
+
+    #[test]
+    fn saving_throw_proficiencies_bard() {
+        let s = SavingThrowProficiencies::bard();
+        assert!(s.dexterity);
+        assert!(s.charisma);
+        assert!(!s.strength);
+    }
+
+    #[test]
+    fn saving_throw_proficiencies_sorcerer() {
+        let s = SavingThrowProficiencies::sorcerer();
+        assert!(s.constitution);
+        assert!(s.charisma);
+        assert!(!s.intelligence);
+    }
+
+    #[test]
+    fn saving_throw_proficiencies_for_class_covers_all_classes() {
+        use crate::combat::types::CharacterClass;
+        let cases = [
+            (CharacterClass::Warrior,   true,  false, true,  false, false, false),
+            (CharacterClass::Fighter,   true,  false, true,  false, false, false),
+            (CharacterClass::Barbarian, true,  false, true,  false, false, false),
+            (CharacterClass::Rogue,     false, true,  false, true,  false, false),
+            (CharacterClass::Bard,      false, true,  false, false, false, true),
+            (CharacterClass::Monk,      true,  true,  false, false, false, false),
+            (CharacterClass::Ranger,    true,  true,  false, false, false, false),
+            (CharacterClass::Paladin,   false, false, false, false, true,  true),
+            (CharacterClass::Cleric,    false, false, false, false, true,  true),
+            (CharacterClass::Warlock,   false, false, false, false, true,  true),
+            (CharacterClass::Mage,      false, false, false, true,  true,  false),
+            (CharacterClass::Wizard,    false, false, false, true,  true,  false),
+            (CharacterClass::Druid,     false, false, false, true,  true,  false),
+            (CharacterClass::Sorcerer,  false, false, true,  false, false, true),
+        ];
+        for (class, str, dex, con, int, wis, cha) in cases {
+            let s = SavingThrowProficiencies::for_class(&class);
+            assert_eq!(s.strength,     str, "{class:?} strength");
+            assert_eq!(s.dexterity,    dex, "{class:?} dexterity");
+            assert_eq!(s.constitution, con, "{class:?} constitution");
+            assert_eq!(s.intelligence, int, "{class:?} intelligence");
+            assert_eq!(s.wisdom,       wis, "{class:?} wisdom");
+            assert_eq!(s.charisma,     cha, "{class:?} charisma");
+        }
+    }
+
+    #[test]
     fn wildlife_kind_default_is_bison() {
         assert_eq!(WildlifeKind::default(), WildlifeKind::Bison);
     }

--- a/crates/shared/src/protocol.rs
+++ b/crates/shared/src/protocol.rs
@@ -9,7 +9,7 @@
 use bevy::ecs::message::Message;
 use bevy::prelude::*;
 use crate::combat::types::CharacterClass;
-use crate::components::{EntityBounds, EntityKind, Experience, FactionBadge, GrowthStage, Health, PlayerStandings, WildlifeKind, WorldMeta, WorldPosition};
+use crate::components::{EntityBounds, EntityKind, Experience, FactionBadge, GrowthStage, Health, PlayerStandings, SavingThrowProficiencies, WildlifeKind, WorldMeta, WorldPosition};
 use crate::world::story::GameEntityId;
 use crate::world::zone::{InteriorTile, Portal, WorldId, ZoneAnchor, ZoneId, ZoneKind};
 use serde::{Deserialize, Serialize};
@@ -149,6 +149,7 @@ impl Plugin for FellytipProtocolPlugin {
         app.register_type::<PlayerStandings>();
         app.register_type::<EntityBounds>();
         app.register_type::<GameEntityId>();
+        app.register_type::<SavingThrowProficiencies>();
         // ChooseClassMessage flows client→server; must be registered before
         // MessageWriter/MessageReader can be used.
         app.add_message::<ChooseClassMessage>();


### PR DESCRIPTION
Closes #106

The core feature was already implemented. This PR fills three gaps:
- Register `SavingThrowProficiencies` in `FellytipProtocolPlugin` so it appears in the BRP/ECS inspector
- Export `roll_saving_throw` from `combat/mod.rs`
- Add tests for all 14 `CharacterClass` variants via `for_class()` plus targeted tests for Paladin, Ranger, Bard, Sorcerer

Generated with [Claude Code](https://claude.ai/code)