### PR TITLE
feat: mesh_gen unified 3-stage pipeline — sprite → mesh → animated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ See `docs/` for product documentation:
 | `tools/worldwatch` | Async egui dashboard — live world inspector + DM control panel over BRP |
 | `tools/world_gen` | ASCII world preview: `cargo run -p world_gen -- --seed N` |
 | `tools/sprite_gen` | Sprite atlas generator: `cargo run -p sprite_gen -- --all` (mock) or `--backend dalle --api-key sk-...` |
+| `tools/mesh_gen` | 3-stage 3D pipeline: `cargo run -p mesh_gen -- --all` (mock) or `--backend live` (requires `SPRITE_GEN_API_KEY` + `MESHY_API_KEY`). Stages: `--stage sprite` (DALL-E PNG), `--stage mesh` (Meshy image-to-3d GLB), `--stage animated` (Meshy text-to-3d rigged GLB, default). Outputs to `assets/sprites/` and `assets/models/`. |
 
 ### Bestiary
 

--- a/tools/mesh_gen/src/dalle.rs
+++ b/tools/mesh_gen/src/dalle.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Result};
+use base64::Engine as _;
 use reqwest::Client;
 use serde::Deserialize;
 
@@ -26,12 +27,12 @@ impl DalleClient {
         Self { client: Client::new(), api_key }
     }
 
-    /// Generate a single reference image for `description`. Returns base64 data URL.
-    pub async fn generate_reference_image(&self, description: &str) -> Result<String> {
+    /// Generate a billboard sprite for `description`. Returns raw PNG bytes.
+    pub async fn generate_billboard_sprite(&self, description: &str) -> Result<Vec<u8>> {
         let prompt = format!(
-            "3D game asset reference sheet: {description}. \
-             Turntable views: front, 3/4, side, back on white background. \
-             Fantasy RPG art style, clean silhouette, suitable for 3D reconstruction."
+            "2D billboard sprite for a fantasy RPG game: {description}. \
+             Front-facing character portrait on a plain white background, \
+             clean silhouette, painterly game-art style."
         );
         let body = serde_json::json!({
             "model": "dall-e-3",
@@ -55,6 +56,7 @@ impl DalleClient {
             .next()
             .and_then(|d| d.b64_json)
             .ok_or_else(|| anyhow::anyhow!("No image data in DALL-E response"))?;
-        Ok(format!("data:image/png;base64,{b64}"))
+        let bytes = base64::engine::general_purpose::STANDARD.decode(&b64)?;
+        Ok(bytes)
     }
 }

--- a/tools/mesh_gen/src/main.rs
+++ b/tools/mesh_gen/src/main.rs
@@ -8,12 +8,15 @@ mod meshy;
 mod pipeline;
 
 use fellytip_shared::bestiary::load_bestiary;
-use pipeline::{Backend, Pipeline};
+use pipeline::{Backend, Pipeline, Stage};
 
 #[derive(Parser)]
-#[command(name = "mesh_gen", about = "GenAI 3D mesh pipeline: DALL-E → Meshy → GLB")]
+#[command(
+    name = "mesh_gen",
+    about = "3D asset pipeline: DALL-E sprite → Meshy static mesh → Meshy rigged+animated mesh"
+)]
 struct Cli {
-    /// Generate mesh for a specific bestiary entity by id
+    /// Generate assets for a specific bestiary entity by id
     #[arg(long)]
     entity: Option<String>,
 
@@ -25,7 +28,7 @@ struct Cli {
     #[arg(long)]
     name: Option<String>,
 
-    /// Generate meshes for all bestiary entities
+    /// Generate assets for all bestiary entities
     #[arg(long)]
     all: bool,
 
@@ -33,15 +36,43 @@ struct Cli {
     #[arg(long, default_value = "mock")]
     backend: BackendArg,
 
+    /// How far to run the pipeline
+    #[arg(long, default_value = "animated")]
+    stage: StageArg,
+
     /// Output directory for GLB files
     #[arg(long, default_value = "assets/models")]
     output: PathBuf,
+
+    /// Output directory for sprite PNG files
+    #[arg(long, default_value = "assets/sprites")]
+    sprite_output: PathBuf,
 }
 
 #[derive(ValueEnum, Clone)]
 enum BackendArg {
     Mock,
     Live,
+}
+
+#[derive(ValueEnum, Clone)]
+enum StageArg {
+    /// Only generate the billboard sprite PNG
+    Sprite,
+    /// Sprite + static textured GLB
+    Mesh,
+    /// Full pipeline: sprite + static mesh + rigged+animated GLB
+    Animated,
+}
+
+impl From<StageArg> for Stage {
+    fn from(s: StageArg) -> Self {
+        match s {
+            StageArg::Sprite => Stage::Sprite,
+            StageArg::Mesh => Stage::Mesh,
+            StageArg::Animated => Stage::Animated,
+        }
+    }
 }
 
 #[tokio::main]
@@ -51,6 +82,7 @@ async fn main() -> Result<()> {
         .init();
 
     let cli = Cli::parse();
+    let stage = Stage::from(cli.stage);
 
     let backend = match cli.backend {
         BackendArg::Mock => Backend::Mock,
@@ -66,36 +98,33 @@ async fn main() -> Result<()> {
         }
     };
 
-    let pipeline = Pipeline { backend, output_dir: cli.output };
+    let pipeline = Pipeline {
+        backend,
+        sprite_dir: cli.sprite_output,
+        model_dir: cli.output,
+    };
 
     if cli.all {
         let bestiary = load_bestiary_from_workspace()?;
         for entry in &bestiary {
-            let desc = format!(
-                "{} — {}",
-                entry.display_name,
-                entry.ai_prompt_base
-            );
+            let desc = format!("{} — {}", entry.display_name, entry.ai_prompt_base);
             let slug = entry.id.to_lowercase().replace(' ', "_");
-            pipeline.run(&slug, &desc).await?;
+            pipeline.run(&slug, &desc, stage).await?;
         }
     } else if let (Some(text), Some(name)) = (cli.text, cli.name) {
-        pipeline.run(&name, &text).await?;
+        pipeline.run(&name, &text, stage).await?;
     } else if let Some(entity_id) = cli.entity {
         let bestiary = load_bestiary_from_workspace()?;
         let entry = bestiary.iter()
             .find(|e| e.id.as_str().eq_ignore_ascii_case(&entity_id))
             .ok_or_else(|| anyhow::anyhow!("Entity '{entity_id}' not found in bestiary"))?;
-        let desc = format!(
-            "{} — {}",
-            entry.display_name,
-            entry.ai_prompt_base
-        );
+        let desc = format!("{} — {}", entry.display_name, entry.ai_prompt_base);
         let slug = entry.id.to_lowercase().replace(' ', "_");
-        pipeline.run(&slug, &desc).await?;
+        pipeline.run(&slug, &desc, stage).await?;
     } else {
         eprintln!("Specify --entity ID, --all, or --text DESC --name NAME");
-        eprintln!("Add --backend live to use real APIs (requires SPRITE_GEN_API_KEY + MESHY_API_KEY)");
+        eprintln!("  --stage sprite|mesh|animated  (default: animated = full pipeline)");
+        eprintln!("  --backend live                (requires SPRITE_GEN_API_KEY + MESHY_API_KEY)");
         std::process::exit(1);
     }
 
@@ -103,7 +132,6 @@ async fn main() -> Result<()> {
 }
 
 fn load_bestiary_from_workspace() -> Result<Vec<fellytip_shared::bestiary::BestiaryEntry>> {
-    // Walk up from cwd to find assets/bestiary.toml
     let mut dir = std::env::current_dir()?;
     loop {
         let p = dir.join("assets/bestiary.toml");

--- a/tools/mesh_gen/src/meshy.rs
+++ b/tools/mesh_gen/src/meshy.rs
@@ -47,18 +47,50 @@ impl MeshyClient {
             .await?;
         if !resp.status().is_success() {
             let text = resp.text().await?;
-            bail!("Meshy submit failed: {text}");
+            bail!("Meshy image-to-3d submit failed: {text}");
         }
         let task: TaskResponse = resp.json().await?;
         Ok(task.result)
     }
 
-    /// Poll task until SUCCEEDED or FAILED. Returns GLB bytes.
-    pub async fn wait_and_download(&self, task_id: &str) -> Result<Vec<u8>> {
+    /// Submit a text-to-3D task with rigging and animation enabled (Meshy v2).
+    pub async fn submit_text_to_animated_3d(&self, prompt: &str) -> Result<String> {
+        let body = serde_json::json!({
+            "mode": "preview",
+            "prompt": prompt,
+            "art_style": "realistic",
+            "should_remesh": true,
+            "should_animate": true,
+        });
+        let resp = self.client
+            .post(format!("{MESHY_BASE}/v2/text-to-3d"))
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let text = resp.text().await?;
+            bail!("Meshy text-to-3d submit failed: {text}");
+        }
+        let task: TaskResponse = resp.json().await?;
+        Ok(task.result)
+    }
+
+    /// Poll image-to-3D task until complete. Returns GLB bytes.
+    pub async fn wait_and_download_image_3d(&self, task_id: &str) -> Result<Vec<u8>> {
+        self.poll_until_done(format!("{MESHY_BASE}/v1/image-to-3d/{task_id}"), task_id).await
+    }
+
+    /// Poll text-to-3D task until complete. Returns animated GLB bytes.
+    pub async fn wait_and_download_text_3d(&self, task_id: &str) -> Result<Vec<u8>> {
+        self.poll_until_done(format!("{MESHY_BASE}/v2/text-to-3d/{task_id}"), task_id).await
+    }
+
+    async fn poll_until_done(&self, url: String, task_id: &str) -> Result<Vec<u8>> {
         loop {
             sleep(Duration::from_secs(5)).await;
             let resp = self.client
-                .get(format!("{MESHY_BASE}/v1/image-to-3d/{task_id}"))
+                .get(&url)
                 .bearer_auth(&self.api_key)
                 .send()
                 .await?
@@ -86,19 +118,34 @@ pub struct MockMeshyClient;
 impl MockMeshyClient {
     /// Returns minimal valid GLB bytes (12-byte GLB header + empty JSON chunk).
     pub fn mock_glb() -> Vec<u8> {
-        // Minimal valid GLB: magic + version + length + chunk0 length + chunk0 type + "{}"
         let json = b"{}";
         let json_padded_len = (json.len() + 3) & !3;
         let mut json_padded = json.to_vec();
         json_padded.resize(json_padded_len, 0x20);
         let total_len = 12 + 8 + json_padded_len as u32;
         let mut glb = Vec::new();
-        glb.extend_from_slice(b"glTF"); // magic
-        glb.extend_from_slice(&2u32.to_le_bytes()); // version
+        glb.extend_from_slice(b"glTF");
+        glb.extend_from_slice(&2u32.to_le_bytes());
         glb.extend_from_slice(&total_len.to_le_bytes());
         glb.extend_from_slice(&(json_padded_len as u32).to_le_bytes());
         glb.extend_from_slice(&0x4E4F534Au32.to_le_bytes()); // JSON chunk type
         glb.extend_from_slice(&json_padded);
         glb
+    }
+
+    /// Returns minimal valid PNG bytes (1×1 white pixel).
+    pub fn mock_png() -> Vec<u8> {
+        // Minimal 1x1 white pixel PNG (well-known byte sequence)
+        vec![
+            0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+            0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, // IHDR length=13
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, // width=1, height=1
+            0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53, // 8bpc RGB, CRC start
+            0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, // CRC end, IDAT length=12
+            0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, // IDAT type + data
+            0x00, 0x00, 0x02, 0x00, 0x01, 0xe2, 0x21, 0xbc, // IDAT data + CRC
+            0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, // IEND length=0 + type
+            0x44, 0xae, 0x42, 0x60, 0x82,                   // IEND CRC
+        ]
     }
 }

--- a/tools/mesh_gen/src/pipeline.rs
+++ b/tools/mesh_gen/src/pipeline.rs
@@ -1,6 +1,21 @@
 use anyhow::Result;
+use base64::Engine as _;
 use std::path::PathBuf;
-use crate::{dalle::DalleClient, meshy::{MeshyClient, MockMeshyClient}};
+
+use crate::{
+    dalle::DalleClient,
+    meshy::{MeshyClient, MockMeshyClient},
+};
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Stage {
+    /// DALL-E 3 → PNG billboard sprite
+    Sprite = 0,
+    /// Sprite PNG → Meshy image-to-3d → static textured GLB
+    Mesh = 1,
+    /// Entity description → Meshy text-to-3d (rigged + animated) → animated GLB
+    Animated = 2,
+}
 
 pub enum Backend {
     Mock,
@@ -9,36 +24,111 @@ pub enum Backend {
 
 pub struct Pipeline {
     pub backend: Backend,
-    pub output_dir: PathBuf,
+    pub sprite_dir: PathBuf,
+    pub model_dir: PathBuf,
+}
+
+pub struct PipelineOutput {
+    pub sprite: Option<PathBuf>,
+    pub mesh: Option<PathBuf>,
+    pub animated: Option<PathBuf>,
 }
 
 impl Pipeline {
-    pub async fn run(&self, entity_name: &str, description: &str) -> Result<PathBuf> {
-        let out_path = self.output_dir.join(format!("{entity_name}.glb"));
+    pub async fn run(
+        &self,
+        entity_name: &str,
+        description: &str,
+        up_to: Stage,
+    ) -> Result<PipelineOutput> {
+        let mut out = PipelineOutput { sprite: None, mesh: None, animated: None };
 
-        if out_path.exists() {
-            tracing::info!("Skipping {entity_name} — already exists at {}", out_path.display());
-            return Ok(out_path);
+        // --- Stage 1: sprite billboard ---
+        let sprite_path = self.sprite_dir.join(format!("{entity_name}.png"));
+        let sprite_data_url: Option<String>;
+
+        if up_to >= Stage::Sprite {
+            if sprite_path.exists() {
+                tracing::info!("Sprite exists, reusing: {}", sprite_path.display());
+                let bytes = std::fs::read(&sprite_path)?;
+                let b64 = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                sprite_data_url = Some(format!("data:image/png;base64,{b64}"));
+            } else {
+                tracing::info!("[stage 1] Generating billboard sprite for: {entity_name}");
+                let png_bytes = match &self.backend {
+                    Backend::Mock => {
+                        tracing::info!("[mock] sprite for {entity_name}");
+                        MockMeshyClient::mock_png()
+                    }
+                    Backend::Live { dalle, .. } => {
+                        dalle.generate_billboard_sprite(description).await?
+                    }
+                };
+                std::fs::create_dir_all(&self.sprite_dir)?;
+                std::fs::write(&sprite_path, &png_bytes)?;
+                tracing::info!("Saved sprite: {}", sprite_path.display());
+                let b64 = base64::engine::general_purpose::STANDARD.encode(&png_bytes);
+                sprite_data_url = Some(format!("data:image/png;base64,{b64}"));
+            }
+            out.sprite = Some(sprite_path.clone());
+        } else {
+            sprite_data_url = None;
         }
 
-        let glb_bytes = match &self.backend {
-            Backend::Mock => {
-                tracing::info!("[mock] Generating mesh for: {entity_name}");
-                MockMeshyClient::mock_glb()
-            }
-            Backend::Live { dalle, meshy } => {
-                tracing::info!("Generating DALL-E reference for: {entity_name}");
-                let image_data_url = dalle.generate_reference_image(description).await?;
-                tracing::info!("Submitting to Meshy...");
-                let task_id = meshy.submit_image_to_3d(&image_data_url).await?;
-                tracing::info!("Task ID: {task_id} — polling...");
-                meshy.wait_and_download(&task_id).await?
-            }
-        };
+        // --- Stage 2: static textured mesh ---
+        let mesh_path = self.model_dir.join(format!("{entity_name}.glb"));
 
-        std::fs::create_dir_all(&self.output_dir)?;
-        std::fs::write(&out_path, &glb_bytes)?;
-        tracing::info!("Saved {}", out_path.display());
-        Ok(out_path)
+        if up_to >= Stage::Mesh {
+            if mesh_path.exists() {
+                tracing::info!("Static mesh exists, skipping: {}", mesh_path.display());
+            } else {
+                tracing::info!("[stage 2] Generating static mesh for: {entity_name}");
+                let glb_bytes = match &self.backend {
+                    Backend::Mock => {
+                        tracing::info!("[mock] static mesh for {entity_name}");
+                        MockMeshyClient::mock_glb()
+                    }
+                    Backend::Live { meshy, .. } => {
+                        let data_url = sprite_data_url
+                            .as_deref()
+                            .ok_or_else(|| anyhow::anyhow!("sprite data URL missing for mesh stage"))?;
+                        let task_id = meshy.submit_image_to_3d(data_url).await?;
+                        tracing::info!("Meshy image-to-3d task: {task_id}");
+                        meshy.wait_and_download_image_3d(&task_id).await?
+                    }
+                };
+                std::fs::create_dir_all(&self.model_dir)?;
+                std::fs::write(&mesh_path, &glb_bytes)?;
+                tracing::info!("Saved static mesh: {}", mesh_path.display());
+            }
+            out.mesh = Some(mesh_path);
+        }
+
+        // --- Stage 3: rigged + animated mesh ---
+        let anim_path = self.model_dir.join(format!("{entity_name}_animated.glb"));
+
+        if up_to >= Stage::Animated {
+            if anim_path.exists() {
+                tracing::info!("Animated mesh exists, skipping: {}", anim_path.display());
+            } else {
+                tracing::info!("[stage 3] Generating rigged+animated mesh for: {entity_name}");
+                let glb_bytes = match &self.backend {
+                    Backend::Mock => {
+                        tracing::info!("[mock] animated mesh for {entity_name}");
+                        MockMeshyClient::mock_glb()
+                    }
+                    Backend::Live { meshy, .. } => {
+                        let task_id = meshy.submit_text_to_animated_3d(description).await?;
+                        tracing::info!("Meshy text-to-3d task: {task_id}");
+                        meshy.wait_and_download_text_3d(&task_id).await?
+                    }
+                };
+                std::fs::write(&anim_path, &glb_bytes)?;
+                tracing::info!("Saved animated mesh: {}", anim_path.display());
+            }
+            out.animated = Some(anim_path);
+        }
+
+        Ok(out)
     }
 }


### PR DESCRIPTION
Extends mesh_gen into a single progressive tool covering all three asset-generation stages:

- Stage 1 (sprite): DALL-E 3 → billboard PNG → assets/sprites/{name}.png
- Stage 2 (mesh): sprite PNG → Meshy image-to-3d → assets/models/{name}.glb
- Stage 3 (animated): text → Meshy text-to-3d (should_animate=true) → assets/models/{name}_animated.glb

New -- stage flag stops the pipeline early. Each stage is skipped if its output already exists (fast incremental reruns).

Closes #142

Generated with [Claude Code](https://claude.ai/code)