### PR TITLE
feat(combat): action economy — ActionBudget + real-time CD (#126)

### DIFF
--- a/crates/client/src/plugins/hud.rs
+++ b/crates/client/src/plugins/hud.rs
@@ -11,7 +11,7 @@
 use bevy::prelude::*;
 use bevy_egui::{EguiContext, EguiContexts, EguiGlobalSettings, EguiPlugin, EguiPrimaryContextPass, PrimaryEguiContext, egui};
 use fellytip_shared::{
-    components::{Experience, Health, PlayerStandings},
+    components::{ActionBudget, Experience, Health, PlayerStandings},
     world::faction::standing_tier,
 };
 use fellytip_server::plugins::party::PartyRegistry;
@@ -20,8 +20,17 @@ use crate::plugins::battle::{BattleLog, ClientStoryLog};
 use crate::plugins::debug_console::DebugConsole;
 use crate::plugins::pause_menu::PauseMenu;
 
-type LocalPlayerQuery<'w, 's> =
-    Query<'w, 's, (&'static Health, &'static Experience, Option<&'static PlayerStandings>), With<LocalPlayer>>;
+type LocalPlayerQuery<'w, 's> = Query<
+    'w,
+    's,
+    (
+        &'static Health,
+        &'static Experience,
+        Option<&'static PlayerStandings>,
+        Option<&'static ActionBudget>,
+    ),
+    With<LocalPlayer>,
+>;
 
 /// Resource tracking whether the character screen is open.
 #[derive(Resource, Default)]
@@ -87,7 +96,7 @@ fn draw_hud(
         .title_bar(false)
         .show(ctx.ctx_mut()?, |ui| {
             match player_q.single() {
-                Ok((health, exp, _)) => {
+                Ok((health, exp, _, budget_opt)) => {
                     ui.heading(format!("Level {}", exp.level));
                     ui.separator();
                     let hp_frac =
@@ -104,6 +113,17 @@ fn draw_hud(
                         egui::ProgressBar::new(xp_frac)
                             .fill(egui::Color32::from_rgb(50, 100, 200)),
                     );
+                    if let Some(budget) = budget_opt {
+                        ui.separator();
+                        ui.horizontal(|ui| {
+                            let ready   = egui::Color32::from_rgb(80, 180, 255);
+                            let spent   = egui::Color32::from_rgb(60, 60, 60);
+                            let pip = |avail: bool| if avail { ready } else { spent };
+                            ui.colored_label(pip(budget.action),       "● A");
+                            ui.colored_label(pip(budget.bonus_action), "● B");
+                            ui.colored_label(pip(budget.reaction),     "◆ R");
+                        });
+                    }
                 }
                 Err(_) => {
                     ui.label("Connecting…");
@@ -186,7 +206,7 @@ fn draw_char_screen(
         .open(&mut open)
         .show(ctx.ctx_mut()?, |ui| {
             match player_q.single() {
-                Ok((health, exp, standings_opt)) => {
+                Ok((health, exp, standings_opt, _)) => {
                     ui.heading(format!("Level {}", exp.level));
                     ui.separator();
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 use fellytip_shared::{
     WORLD_SEED,
     combat::{interrupt::InterruptStack, types::{CharacterClass, CombatantId}, SpellSlots, Spellbook},
-    components::{AbilityModifiers, AbilityScores, Experience, Health, HitDice, PlayerStandings, SavingThrowProficiencies, WorldMeta, WorldPosition},
+    components::{AbilityModifiers, AbilityScores, ActionBudget, Experience, Health, HitDice, PlayerStandings, SavingThrowProficiencies, WorldMeta, WorldPosition},
     protocol::ChooseClassMessage,
     world::{
         map::{find_surface_spawn, WorldMap, MAP_HEIGHT, MAP_WIDTH},
@@ -16,7 +16,7 @@ use fellytip_shared::{
 use uuid::Uuid;
 
 use plugins::character_persistence::{load_character, load_local_player_uuid, save_character, store_local_player_uuid};
-use plugins::combat::{CombatParticipant, LastPlayerInput, PositionSanityTimer};
+use plugins::combat::{ActionCooldowns, CombatParticipant, LastPlayerInput, PositionSanityTimer};
 use plugins::persistence::Db;
 pub use plugins::map_gen::MapGenConfig;
 
@@ -244,6 +244,7 @@ fn spawn_player_on_class_choice(
             ..default()
         },
         (world_meta, spell_slots, spellbook),
+        (ActionBudget::default(), ActionCooldowns::default()),
     ));
     tracing::info!(uuid = %player_uuid, x = px, y = py, z = pz, "Player spawned after class selection");
 }

--- a/crates/server/src/plugins/combat.rs
+++ b/crates/server/src/plugins/combat.rs
@@ -20,7 +20,7 @@ use fellytip_shared::{
             CoreStats, Effect,
         },
     },
-    components::{EntityKind, Experience, Health, Pacifist, WorldPosition},
+    components::{ActionBudget, ActionSlot, ActionUsedEvent, EntityKind, Experience, Health, Pacifist, WorldPosition},
     inputs::ActionIntent,
     world::{
         ecology::RegionId,
@@ -139,11 +139,26 @@ pub struct PendingSpell {
     pub slot_level: u8,
 }
 
+/// D&D 5e round duration in real-time mode (seconds). Matches the 6-second initiative round.
+const ROUND_SECONDS: f32 = 6.0;
+
+/// Server-only cooldown timers that drive `ActionBudget` slot restoration.
+///
+/// Each field counts down in seconds; when it hits 0 the corresponding
+/// `ActionBudget` boolean is restored to `true`.
+#[derive(Component, Default)]
+pub struct ActionCooldowns {
+    pub action_cd:       f32,
+    pub bonus_action_cd: f32,
+    pub reaction_cd:     f32,
+}
+
 pub struct CombatPlugin;
 
 impl Plugin for CombatPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<LocalPlayerInput>();
+        app.add_message::<ActionUsedEvent>();
         app.add_systems(
             FixedUpdate,
             check_faction_aggression
@@ -151,8 +166,38 @@ impl Plugin for CombatPlugin {
         );
         app.add_systems(
             FixedUpdate,
+            tick_action_cooldowns.before(process_player_input),
+        );
+        app.add_systems(
+            FixedUpdate,
             (process_player_input, initiate_attacks, initiate_abilities, initiate_spells, resolve_interrupts).chain(),
         );
+    }
+}
+
+// ── Action economy cooldown tick ─────────────────────────────────────────────
+
+/// Decrement real-time action cooldowns and restore slots when they expire.
+fn tick_action_cooldowns(
+    time: Res<Time>,
+    mut q: Query<(&mut ActionBudget, &mut ActionCooldowns)>,
+) {
+    let dt = time.delta_secs();
+    for (mut budget, mut cds) in &mut q {
+        restore_slot(&mut cds.action_cd, &mut budget.action, dt);
+        restore_slot(&mut cds.bonus_action_cd, &mut budget.bonus_action, dt);
+        restore_slot(&mut cds.reaction_cd, &mut budget.reaction, dt);
+    }
+}
+
+#[inline]
+fn restore_slot(cd: &mut f32, available: &mut bool, dt: f32) {
+    if *cd > 0.0 {
+        *cd -= dt;
+        if *cd <= 0.0 {
+            *cd = 0.0;
+            *available = true;
+        }
     }
 }
 
@@ -251,26 +296,49 @@ fn check_faction_aggression(
 
 // ── Input processing ──────────────────────────────────────────────────────────
 
+type PlayerBudgetQuery<'w, 's> = Query<
+    'w,
+    's,
+    (Entity, Option<&'static mut ActionBudget>, Option<&'static mut ActionCooldowns>),
+    Without<ExperienceReward>,
+>;
+
 /// Drain `LocalPlayerInput` actions and queue combat markers on the player entity.
 ///
 /// Movement is handled by `sync_pred_to_world` in the client (Update); this
 /// system only processes the action intents accumulated since the last tick.
 ///
+/// When the player entity has an `ActionBudget`, each action consumes the
+/// appropriate slot and starts a `ROUND_SECONDS` cooldown via `ActionCooldowns`.
+/// Actions are silently discarded when the relevant slot is spent.
+///
 /// MULTIPLAYER: restore MessageReceiver<PlayerInput> iteration over ClientOf
 /// entities and re-add the position-acceptance + sanity-timer logic.
 fn process_player_input(
     mut local_input: ResMut<LocalPlayerInput>,
-    player_q: Query<Entity, Without<ExperienceReward>>,
+    mut player_q: PlayerBudgetQuery,
     enemies: Query<(Entity, &CombatParticipant), With<ExperienceReward>>,
+    mut action_used: MessageWriter<ActionUsedEvent>,
     mut commands: Commands,
 ) {
-    let Ok(player_entity) = player_q.single() else { return };
+    let Ok((player_entity, mut budget_opt, mut cds_opt)) = player_q.single_mut() else { return };
+
     let pending_actions: Vec<(Option<ActionIntent>, Option<uuid::Uuid>)> =
         local_input.actions.drain(..).collect();
 
     for (action, target_uuid) in pending_actions {
         match action {
             Some(ActionIntent::BasicAttack) => {
+                if let Some(budget) = budget_opt.as_deref_mut() {
+                    if !budget.consume(ActionSlot::Action) {
+                        tracing::debug!("BasicAttack blocked: Action slot spent");
+                        continue;
+                    }
+                    if let Some(cds) = cds_opt.as_deref_mut() {
+                        cds.action_cd = ROUND_SECONDS;
+                    }
+                    action_used.write(ActionUsedEvent { entity: player_entity, slot: ActionSlot::Action });
+                }
                 let target = if let Some(uuid) = target_uuid {
                     enemies.iter().find(|(_, p)| p.id.0 == uuid).map(|(e, _)| e)
                 } else {
@@ -284,6 +352,16 @@ fn process_player_input(
                 }
             }
             Some(ActionIntent::UseAbility(ability_id)) => {
+                if let Some(budget) = budget_opt.as_deref_mut() {
+                    if !budget.consume(ActionSlot::Action) {
+                        tracing::debug!("UseAbility blocked: Action slot spent");
+                        continue;
+                    }
+                    if let Some(cds) = cds_opt.as_deref_mut() {
+                        cds.action_cd = ROUND_SECONDS;
+                    }
+                    action_used.write(ActionUsedEvent { entity: player_entity, slot: ActionSlot::Action });
+                }
                 let target = if let Some(uuid) = target_uuid {
                     enemies.iter().find(|(_, p)| p.id.0 == uuid).map(|(e, _)| e)
                 } else {
@@ -431,6 +509,7 @@ type ParticipantQuery<'w, 's> = Query<
 >;
 
 /// Step each active interrupt stack; apply effects; award XP on kills.
+#[allow(clippy::too_many_arguments)]
 fn resolve_interrupts(
     mut participants: ParticipantQuery,
     wildlife_loot_query: Query<(Entity, &WorldPosition, &Loot, &EntityKind), With<Loot>>,

--- a/crates/server/src/plugins/portal.rs
+++ b/crates/server/src/plugins/portal.rs
@@ -131,8 +131,14 @@ fn tick_portal_cooldowns(
 /// For each non-trigger entity with a `ZoneMembership`, emit a
 /// `PlayerZoneTransition` when it enters any same-zone `PortalTrigger`'s
 /// radius. Entities with an active `PortalCooldown` are skipped.
+type MoverQuery<'w, 's> = Query<
+    'w, 's,
+    (Entity, &'static WorldPosition, &'static ZoneMembership),
+    (Without<PortalTrigger>, Without<PortalCooldown>),
+>;
+
 fn check_portal_triggers(
-    movers: Query<(Entity, &WorldPosition, &ZoneMembership), (Without<PortalTrigger>, Without<PortalCooldown>)>,
+    movers: MoverQuery,
     triggers: Query<(&PortalTrigger, &WorldPosition, &ZoneMembership)>,
     topology: Option<Res<ZoneTopology>>,
     mut out: MessageWriter<PlayerZoneTransition>,

--- a/crates/shared/src/components.rs
+++ b/crates/shared/src/components.rs
@@ -2,6 +2,7 @@
 
 use crate::combat::types::CharacterClass;
 use crate::world::faction::NpcRank;
+use bevy::ecs::message::Message;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -543,6 +544,73 @@ impl SavingThrowProficiencies {
     }
 }
 
+// ── Action Economy (#126) ─────────────────────────────────────────────────────
+
+/// Which action economy slot an ability consumes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Reflect)]
+pub enum ActionSlot {
+    /// Standard action: basic attack, use item, cast a spell.
+    Action,
+    /// Bonus action: off-hand attack, some class features.
+    BonusAction,
+    /// Reaction: opportunity attack, Shield spell.
+    Reaction,
+}
+
+/// Per-round action economy budget (D&D 5e: Action, Bonus Action, Reaction, movement).
+///
+/// In real-time mode, spent slots recharge after ~6 s (one D&D round) via
+/// `ActionCooldowns` on the server.  In future turn-based mode, all slots reset
+/// at the top of each combatant's turn.
+///
+/// Server-authoritative; replicated to clients so the HUD can render pip indicators.
+#[derive(Component, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
+#[reflect(Component)]
+pub struct ActionBudget {
+    /// Standard action (basic attack, spell, use item). Recharges after one round.
+    pub action: bool,
+    /// Bonus action (off-hand attack, some class features). Recharges after one round.
+    pub bonus_action: bool,
+    /// Reaction (opportunity attack). One per round.
+    pub reaction: bool,
+    /// Remaining movement this round in world units (default = PLAYER_SPEED × 6 s = 15.0).
+    pub movement_remaining: f32,
+}
+
+impl Default for ActionBudget {
+    fn default() -> Self {
+        Self {
+            action: true,
+            bonus_action: true,
+            reaction: true,
+            movement_remaining: 15.0,
+        }
+    }
+}
+
+impl ActionBudget {
+    /// Try to spend the given slot. Returns `true` if it was available and is now spent.
+    pub fn consume(&mut self, slot: ActionSlot) -> bool {
+        match slot {
+            ActionSlot::Action      => std::mem::replace(&mut self.action, false),
+            ActionSlot::BonusAction => std::mem::replace(&mut self.bonus_action, false),
+            ActionSlot::Reaction    => std::mem::replace(&mut self.reaction, false),
+        }
+    }
+
+    /// Restore all slots and reset movement to the default.
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+/// Broadcast when a combatant spends an action slot — animation and audio hook.
+#[derive(Message, Clone, Debug)]
+pub struct ActionUsedEvent {
+    pub entity: Entity,
+    pub slot: ActionSlot,
+}
+
 // ── NPC Dialogue Flavor (#131) ────────────────────────────────────────────────
 
 /// Return a short greeting line for the given class and rank.
@@ -771,5 +839,50 @@ mod tests {
             let back: WildlifeKind = serde_json::from_str(&json).unwrap();
             assert_eq!(variant, back);
         }
+    }
+
+    #[test]
+    fn action_budget_default_all_available() {
+        let b = ActionBudget::default();
+        assert!(b.action);
+        assert!(b.bonus_action);
+        assert!(b.reaction);
+        assert!(b.movement_remaining > 0.0);
+    }
+
+    #[test]
+    fn action_budget_consume_action() {
+        let mut b = ActionBudget::default();
+        assert!(b.consume(ActionSlot::Action));
+        assert!(!b.action);
+        assert!(b.bonus_action);
+        assert!(b.reaction);
+    }
+
+    #[test]
+    fn action_budget_cannot_double_spend() {
+        let mut b = ActionBudget::default();
+        assert!(b.consume(ActionSlot::BonusAction));
+        assert!(!b.consume(ActionSlot::BonusAction));
+    }
+
+    #[test]
+    fn action_budget_reset_restores_all() {
+        let mut b = ActionBudget::default();
+        b.consume(ActionSlot::Action);
+        b.consume(ActionSlot::BonusAction);
+        b.consume(ActionSlot::Reaction);
+        b.reset();
+        assert!(b.action);
+        assert!(b.bonus_action);
+        assert!(b.reaction);
+    }
+
+    #[test]
+    fn action_budget_serde_round_trip() {
+        let b = ActionBudget { action: false, bonus_action: true, reaction: false, movement_remaining: 7.5 };
+        let json = serde_json::to_string(&b).unwrap();
+        let back: ActionBudget = serde_json::from_str(&json).unwrap();
+        assert_eq!(b, back);
     }
 }

--- a/crates/shared/src/protocol.rs
+++ b/crates/shared/src/protocol.rs
@@ -9,7 +9,7 @@
 use bevy::ecs::message::Message;
 use bevy::prelude::*;
 use crate::combat::types::CharacterClass;
-use crate::components::{EntityBounds, EntityKind, Experience, FactionBadge, GrowthStage, Health, PlayerStandings, SavingThrowProficiencies, WildlifeKind, WorldMeta, WorldPosition};
+use crate::components::{ActionBudget, EntityBounds, EntityKind, Experience, FactionBadge, GrowthStage, Health, PlayerStandings, SavingThrowProficiencies, WildlifeKind, WorldMeta, WorldPosition};
 use crate::world::story::GameEntityId;
 use crate::world::zone::{InteriorTile, Portal, WorldId, ZoneAnchor, ZoneId, ZoneKind};
 use serde::{Deserialize, Serialize};
@@ -150,6 +150,7 @@ impl Plugin for FellytipProtocolPlugin {
         app.register_type::<EntityBounds>();
         app.register_type::<GameEntityId>();
         app.register_type::<SavingThrowProficiencies>();
+        app.register_type::<ActionBudget>();
         // ChooseClassMessage flows client→server; must be registered before
         // MessageWriter/MessageReader can be used.
         app.add_message::<ChooseClassMessage>();

--- a/docs/systems/combat.md
+++ b/docs/systems/combat.md
@@ -37,8 +37,11 @@ The bridge runs in `FixedUpdate`. System ordering:
 **`check_faction_aggression`** (runs before `process_player_input`)
 Queries all faction NPCs without a pending attack and all players. For each NPC within 10 tiles of a player, inserts `PendingAttack` if the faction's `is_aggressive` flag is set or the player's standing tier is Hostile/Hated. Uses `PlayerReputationMap` and `FactionRegistry` resources. See `docs/systems/factions.md` for aggression rules.
 
+**`tick_action_cooldowns`** (runs before `process_player_input`)
+Decrements real-time CD timers on `ActionCooldowns` and restores the corresponding `ActionBudget` boolean when each timer reaches zero. Round duration = 6 s (`ROUND_SECONDS`).
+
 **`process_player_input`**
-Reads `PlayerInput` messages from each connected client. Applies movement to `WorldPosition`. When `BasicAttack` is present, inserts `PendingAttack`; when `UseAbility(id)` is present, inserts `PendingAbility`.
+Reads `PlayerInput` messages from each connected client. Applies movement to `WorldPosition`. When `BasicAttack` is present and the player's `ActionBudget.action` is available, consumes the slot, starts a 6 s `ActionCooldowns.action_cd`, emits `ActionUsedEvent`, and inserts `PendingAttack`. Actions requested while a slot is spent are silently discarded. If no `ActionBudget` is present the action always proceeds (backward-compatible). When `UseAbility(id)` is present the same Action-slot check applies before inserting `PendingAbility`.
 
 **`initiate_attacks`**
 Converts `PendingAttack` markers into `InterruptFrame::ResolvingAttack` values pushed onto the attacker's `InterruptStack`. Removes the marker.
@@ -71,8 +74,17 @@ On each level-up, HP increases by rolling the class hit die + CON modifier (mini
 | `ExperienceReward(u32)` | XP granted to the killer; only on NPCs and bosses. Set from CR table in `docs/dnd5e-srd-reference.md`. |
 | `PendingAttack { target }` | Transient marker; consumed by `initiate_attacks` |
 | `PendingAbility { target, ability_id }` | Transient marker; consumed by `initiate_abilities` |
+| `ActionCooldowns` | Server-only CD timers (`action_cd`, `bonus_action_cd`, `reaction_cd` in seconds) that drive `ActionBudget` restoration |
 | `PlayerEntity(Entity)` | Links a `ClientOf` entity to its spawned player entity |
 | `GameEntityId(Uuid)` | Stable cross-session identity on player entities; `CombatantId.0 == GameEntityId.0` for all players |
+
+## Shared action-economy components (replicated)
+
+| Component | Description |
+|---|---|
+| `ActionBudget` | Per-round booleans: `action`, `bonus_action`, `reaction` (true = available) plus `movement_remaining: f32`. Default = all true, 15.0 movement. Registered in `FellytipProtocolPlugin` for BRP inspection. |
+| `ActionSlot` | Enum: `Action`, `BonusAction`, `Reaction` — which slot an ability consumes. |
+| `ActionUsedEvent` | `Message` broadcast each time a player spends a slot; carries `entity` and `slot`. Hook for animation/audio. |
 
 ## Character classes
 
@@ -103,3 +115,5 @@ The Hollow King has three combat phases tracked by `BossPhase` component on the 
 ## Current state
 
 Basic attack (Space) → damage → death → XP loop is fully functional. StrongAttack (Q) is ability 1. Three character classes are implemented with class-appropriate modifiers and distinct abilities (ids 1–3). The dungeon boss ("The Hollow King") has phased abilities at 50% and 25% HP thresholds. Movement reactions (`ResolvingMovement`) are scaffolded but unimplemented. Faction alert state (`FactionAlertState`) raises NPC patrol radius and speed after any battle; see `docs/systems/factions.md`.
+
+Action economy is implemented in real-time mode: the player entity carries `ActionBudget` (all slots true on spawn) and `ActionCooldowns`. Each basic attack or ability use consumes the `Action` slot and starts a 6 s CD; attempts while the slot is spent are discarded. The HUD shows three pip indicators (● A, ● B, ◆ R) below the XP bar: bright = available, grey = spent. Bonus-action and reaction economy tracking is wired but not yet consumed by any specific ability.


### PR DESCRIPTION
Implements D&D 5e per-round action economy as specified in #126.

Cherry-pick of b80542c onto master with merge conflict resolved: `SavingThrowProficiencies` (master) + `ActionBudget` (this branch) both registered in `FellytipProtocolPlugin`.

Closes #126

Generated with [Claude Code](https://claude.ai/code)