### PR TITLE
feat(#123): mouse-driven combat — targeted attacks, context menu, floating text

### DIFF
--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -93,6 +93,8 @@ fn add_windowed_plugins(app: &mut App) {
     .add_plugins(plugins::ZoneRendererPlugin)
     .add_plugins(plugins::PortalRendererPlugin)
     .add_plugins(plugins::ParticlesPlugin)
+    .add_plugins(plugins::TargetSelectPlugin)
+    .add_plugins(plugins::FloatingTextPlugin)
     .add_plugins(plugins::ActionMenuPlugin);
 }
 
@@ -272,6 +274,7 @@ fn send_player_input(
     keyboard: Option<Res<ButtonInput<KeyCode>>>,
     mouse: Option<Res<ButtonInput<MouseButton>>>,
     egui_consumed: Option<Res<plugins::EguiPointerConsumed>>,
+    hovered_target: Option<Res<plugins::target_select::HoveredTarget>>,
     camera_q: Query<&OrbitCamera>,
     mut pred_q: Query<(&mut PredictedPosition, &EntityBounds), With<LocalPlayer>>,
     map: Option<Res<WorldMap>>,
@@ -426,7 +429,8 @@ fn send_player_input(
     }
 
     // Queue combat action intents for server-side processing.
-    // Left-click = basic attack (unless egui consumed the pointer).
+    // Left-click on a hovered enemy = targeted basic attack.
+    // Left-click on empty space = attack nearest enemy (fallback).
     let egui_over = egui_consumed.as_ref().is_some_and(|e| e.0);
     let lmb_attack = !egui_over && mouse.as_ref().is_some_and(|m| m.just_pressed(MouseButton::Left));
     let action = if lmb_attack || keyboard.just_pressed(KeyCode::KeyQ) {
@@ -437,7 +441,12 @@ fn send_player_input(
         None
     };
     if action.is_some() {
-        local_input.actions.push((action, None));
+        let target_uuid = if lmb_attack {
+            hovered_target.as_ref().and_then(|h| h.0.map(|(_, uuid)| uuid))
+        } else {
+            None
+        };
+        local_input.actions.push((action, target_uuid));
     }
 }
 

--- a/crates/client/src/plugins/action_menu.rs
+++ b/crates/client/src/plugins/action_menu.rs
@@ -1,18 +1,35 @@
-//! Right-click action popup menu for combat.
+//! Right-click context menu for combat and interaction.
+//!
+//! The menu content adapts based on what was under the cursor when right-click
+//! was pressed:
+//!   - **Hostile entity**: Attack (targeted), Class Action, Dodge, Cancel
+//!   - **No target / tile**: Attack (nearest), Ability, Dodge, Cancel
 
 use bevy::prelude::*;
 use bevy_egui::{EguiContexts, EguiPrimaryContextPass, egui};
+use uuid::Uuid;
 use fellytip_shared::inputs::ActionIntent;
 use fellytip_server::plugins::combat::LocalPlayerInput;
+use super::target_select::HoveredTarget;
 
 /// Set to true this frame if egui consumed the pointer (so left-click attack is suppressed).
 #[derive(Resource, Default)]
 pub struct EguiPointerConsumed(pub bool);
 
+/// What the cursor was over when the action menu was opened.
+#[derive(Debug, Clone, Default)]
+pub enum TargetContext {
+    #[default]
+    None,
+    /// A specific hostile entity identified by its combat UUID.
+    Hostile { uuid: Uuid },
+}
+
 #[derive(Resource, Default)]
 pub struct ActionMenuState {
     pub open: bool,
     pub screen_pos: egui::Pos2,
+    pub context: TargetContext,
 }
 
 pub struct ActionMenuPlugin;
@@ -20,25 +37,32 @@ pub struct ActionMenuPlugin;
 impl Plugin for ActionMenuPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ActionMenuState>()
-           .init_resource::<EguiPointerConsumed>()
-           .add_systems(Update, handle_right_click)
-           .add_systems(EguiPrimaryContextPass, draw_action_menu);
+            .init_resource::<EguiPointerConsumed>()
+            .add_systems(Update, handle_right_click)
+            .add_systems(EguiPrimaryContextPass, draw_action_menu);
     }
 }
 
 fn handle_right_click(
     mouse: Option<Res<ButtonInput<MouseButton>>>,
     windows: Query<&Window>,
+    hovered: Option<Res<HoveredTarget>>,
     mut state: ResMut<ActionMenuState>,
 ) {
     let Some(mouse) = mouse else { return };
     if mouse.just_pressed(MouseButton::Right) {
-        let cursor_pos = windows.single()
+        let cursor_pos = windows
+            .single()
             .ok()
             .and_then(|w| w.cursor_position())
             .unwrap_or(Vec2::ZERO);
         state.open = true;
         state.screen_pos = egui::pos2(cursor_pos.x, cursor_pos.y);
+        state.context = hovered
+            .as_ref()
+            .and_then(|h| h.0)
+            .map(|(_, uuid)| TargetContext::Hostile { uuid })
+            .unwrap_or(TargetContext::None);
     }
     if mouse.just_pressed(MouseButton::Left) && state.open {
         state.open = false;
@@ -52,31 +76,90 @@ fn draw_action_menu(
     mut consumed: ResMut<EguiPointerConsumed>,
 ) -> Result {
     consumed.0 = false;
-    if !state.open { return Ok(()); }
+    if !state.open {
+        return Ok(());
+    }
 
     let egui_ctx = ctx.ctx_mut()?;
     consumed.0 = egui_ctx.is_pointer_over_area();
+
+    let context = state.context.clone();
 
     egui::Area::new("action_menu".into())
         .fixed_pos(state.screen_pos)
         .order(egui::Order::Foreground)
         .show(egui_ctx, |ui| {
             egui::Frame::popup(ui.style()).show(ui, |ui| {
-                ui.set_min_width(140.0);
-                ui.label(egui::RichText::new("Actions").strong());
-                ui.separator();
-                if ui.button("⚔ Attack").clicked() {
-                    local_input.actions.push((Some(ActionIntent::BasicAttack), None));
-                    state.open = false;
+                ui.set_min_width(160.0);
+
+                match &context {
+                    TargetContext::Hostile { uuid } => {
+                        let uuid = *uuid;
+                        ui.label(egui::RichText::new("Combat").strong());
+                        ui.separator();
+                        if ui.button("⚔ Attack").clicked() {
+                            local_input
+                                .actions
+                                .push((Some(ActionIntent::BasicAttack), Some(uuid)));
+                            state.open = false;
+                        }
+                        if ui
+                            .add_enabled(false, egui::Button::new("↗ Shove"))
+                            .clicked()
+                        {
+                            state.open = false;
+                        }
+                        if ui
+                            .add_enabled(false, egui::Button::new("🤝 Grapple"))
+                            .clicked()
+                        {
+                            state.open = false;
+                        }
+                        ui.separator();
+                        if ui.button("✦ Class Action").clicked() {
+                            local_input
+                                .actions
+                                .push((Some(ActionIntent::UseAbility(1)), Some(uuid)));
+                            state.open = false;
+                        }
+                        if ui.button("🛡 Dodge").clicked() {
+                            local_input
+                                .actions
+                                .push((Some(ActionIntent::Dodge), None));
+                            state.open = false;
+                        }
+                    }
+                    TargetContext::None => {
+                        ui.label(egui::RichText::new("Actions").strong());
+                        ui.separator();
+                        if ui.button("⚔ Attack").clicked() {
+                            local_input
+                                .actions
+                                .push((Some(ActionIntent::BasicAttack), None));
+                            state.open = false;
+                        }
+                        if ui.button("✦ Ability").clicked() {
+                            local_input
+                                .actions
+                                .push((Some(ActionIntent::UseAbility(1)), None));
+                            state.open = false;
+                        }
+                        if ui.button("🛡 Dodge").clicked() {
+                            local_input
+                                .actions
+                                .push((Some(ActionIntent::Dodge), None));
+                            state.open = false;
+                        }
+                        ui.separator();
+                        if ui
+                            .add_enabled(false, egui::Button::new("👁 Examine"))
+                            .clicked()
+                        {
+                            state.open = false;
+                        }
+                    }
                 }
-                if ui.button("✦ Ability").clicked() {
-                    local_input.actions.push((Some(ActionIntent::UseAbility(1)), None));
-                    state.open = false;
-                }
-                if ui.button("🛡 Dodge").clicked() {
-                    local_input.actions.push((Some(ActionIntent::Dodge), None));
-                    state.open = false;
-                }
+
                 ui.separator();
                 if ui.button("✕ Cancel").clicked() {
                     state.open = false;

--- a/crates/client/src/plugins/floating_text.rs
+++ b/crates/client/src/plugins/floating_text.rs
@@ -1,0 +1,135 @@
+//! Floating combat text overlay (damage numbers, "Miss!", critical hits).
+//!
+//! Listens to `ClientDamageMsg` and renders transient labels above the impact
+//! point using egui Areas projected from world-space to screen-space.
+//!
+//! Visual scheme:
+//!   - Regular hit  : white number, 14 px, floats up, fades out over 1.2 s
+//!   - Miss         : grey "Miss!", 13 px, fades out over 1.0 s
+//!   - Critical hit : gold number + "!", 20 px, fades out over 1.5 s
+
+use bevy::ecs::message::MessageReader;
+use bevy::prelude::*;
+use bevy_egui::{EguiContexts, EguiPrimaryContextPass, egui};
+use fellytip_shared::protocol::ClientDamageMsg;
+use super::camera::OrbitCamera;
+
+#[derive(Clone)]
+struct FloatEntry {
+    /// Impact position in Bevy world space (x, y_up, z).
+    world_pos: Vec3,
+    text: String,
+    color: egui::Color32,
+    font_size: f32,
+    age: f32,
+    max_age: f32,
+}
+
+#[derive(Resource, Default)]
+pub struct FloatingTextQueue(Vec<FloatEntry>);
+
+pub struct FloatingTextPlugin;
+
+impl Plugin for FloatingTextPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<FloatingTextQueue>()
+            .add_systems(Update, enqueue_damage_texts)
+            .add_systems(EguiPrimaryContextPass, draw_floating_texts);
+    }
+}
+
+fn enqueue_damage_texts(
+    mut messages: MessageReader<ClientDamageMsg>,
+    mut queue: ResMut<FloatingTextQueue>,
+) {
+    for msg in messages.read() {
+        // msg.x/y/z are already in Bevy space (emitted as pos.x, pos.z, pos.y).
+        // Offset upward by 1.8 units so text appears above the entity's head.
+        let world_pos = Vec3::new(msg.x, msg.y + 1.8, msg.z);
+
+        let entry = if msg.is_miss {
+            FloatEntry {
+                world_pos,
+                text: "Miss!".to_string(),
+                color: egui::Color32::from_rgb(180, 180, 180),
+                font_size: 13.0,
+                age: 0.0,
+                max_age: 1.0,
+            }
+        } else if msg.is_critical {
+            FloatEntry {
+                world_pos,
+                text: format!("{}!", msg.damage),
+                color: egui::Color32::from_rgb(255, 200, 0),
+                font_size: 20.0,
+                age: 0.0,
+                max_age: 1.5,
+            }
+        } else {
+            FloatEntry {
+                world_pos,
+                text: msg.damage.to_string(),
+                color: egui::Color32::WHITE,
+                font_size: 14.0,
+                age: 0.0,
+                max_age: 1.2,
+            }
+        };
+        queue.0.push(entry);
+    }
+}
+
+fn draw_floating_texts(
+    mut ctx: EguiContexts,
+    mut queue: ResMut<FloatingTextQueue>,
+    camera_q: Query<(&Camera, &GlobalTransform), With<OrbitCamera>>,
+    time: Res<Time>,
+) -> Result {
+    let egui_ctx = ctx.ctx_mut()?;
+    let Ok((camera, camera_transform)) = camera_q.single() else {
+        return Ok(());
+    };
+    let dt = time.delta_secs();
+
+    let mut i = 0;
+    while i < queue.0.len() {
+        queue.0[i].age += dt;
+        if queue.0[i].age >= queue.0[i].max_age {
+            queue.0.swap_remove(i);
+            continue;
+        }
+
+        let entry = &queue.0[i];
+        let t = entry.age / entry.max_age;
+        // Float upward 40 logical pixels over the full lifetime.
+        let float_px = t * 40.0;
+        let alpha = ((1.0 - t) * 255.0) as u8;
+
+        if let Ok(screen_pos) = camera.world_to_viewport(camera_transform, entry.world_pos) {
+            let color = egui::Color32::from_rgba_unmultiplied(
+                entry.color.r(),
+                entry.color.g(),
+                entry.color.b(),
+                alpha,
+            );
+            let text = entry.text.clone();
+            let font_size = entry.font_size;
+            egui::Area::new(egui::Id::new(("float_text", i, entry.age.to_bits())))
+                .fixed_pos(egui::pos2(screen_pos.x - 20.0, screen_pos.y - float_px))
+                .interactable(false)
+                .order(egui::Order::Tooltip)
+                .show(egui_ctx, |ui| {
+                    ui.label(
+                        egui::RichText::new(text)
+                            .color(color)
+                            .size(font_size)
+                            .strong(),
+                    );
+                });
+        }
+
+        i += 1;
+    }
+
+    Ok(())
+}

--- a/crates/client/src/plugins/mod.rs
+++ b/crates/client/src/plugins/mod.rs
@@ -1,6 +1,7 @@
 pub mod action_menu;
 pub mod battle;
 pub mod billboard_sprite;
+pub mod floating_text;
 pub mod particles;
 pub mod camera;
 pub mod character_animation;
@@ -15,6 +16,7 @@ pub mod scene_decoration;
 pub mod scene_lighting;
 pub mod settings;
 pub mod skybox;
+pub mod target_select;
 pub mod terrain;
 pub mod zone_cache;
 pub mod zone_renderer;
@@ -27,6 +29,7 @@ pub use character_animation::CharacterAnimationPlugin;
 pub use class_selection::{ClassSelectionPlugin, ClassSelectionState};
 pub use debug_console::{DebugConsole, DebugConsolePlugin};
 pub use entity_renderer::EntityRendererPlugin;
+pub use floating_text::FloatingTextPlugin;
 pub use hud::{CharScreen, HudPlugin};
 pub use map::{MapPlugin, MapWindow};
 pub use pause_menu::PauseMenuPlugin;
@@ -36,6 +39,7 @@ pub use scene_lighting::SceneLightingPlugin;
 #[allow(unused_imports)]
 pub use settings::{GraphicsSettings, SettingsPlugin};
 pub use skybox::SkyboxPlugin;
+pub use target_select::TargetSelectPlugin;
 pub use terrain::TerrainPlugin;
 #[allow(unused_imports)]
 pub use zone_cache::{ZoneCache, ZoneCachePlugin};

--- a/crates/client/src/plugins/particles.rs
+++ b/crates/client/src/plugins/particles.rs
@@ -214,6 +214,7 @@ fn spawn_combat_particles(
     let mut rng = rand::rng();
 
     for msg in messages.read() {
+        if msg.is_miss { continue; }
         let origin = Vec3::new(msg.x, msg.y, msg.z);
         if msg.is_spell {
             // SpellImpact: 12 particles, colour by spell type, 0.2 s lifetime

--- a/crates/client/src/plugins/target_select.rs
+++ b/crates/client/src/plugins/target_select.rs
@@ -1,0 +1,72 @@
+//! Screen-space entity picking: finds the nearest hostile entity under the cursor.
+//!
+//! Projects each enemy's world position to viewport coordinates each frame and
+//! tracks the closest one within `PICK_RADIUS_PX` pixels of the cursor.
+//! The result is exposed as the `HoveredTarget` resource consumed by the input
+//! system (targeted left-click attack) and the action menu (context-aware
+//! right-click menu).
+
+use bevy::prelude::*;
+use uuid::Uuid;
+use fellytip_server::plugins::combat::{CombatParticipant, ExperienceReward};
+use fellytip_shared::components::{Pacifist, WorldPosition};
+use super::action_menu::EguiPointerConsumed;
+use super::camera::OrbitCamera;
+
+/// How close (in logical pixels) the cursor must be to an enemy's projected
+/// screen position for that enemy to be considered hovered.
+const PICK_RADIUS_PX: f32 = 60.0;
+
+/// The hostile entity (if any) currently closest to the cursor, together with
+/// its combat UUID (used to route the targeted attack to the server).
+#[derive(Resource, Default)]
+pub struct HoveredTarget(pub Option<(Entity, Uuid)>);
+
+pub struct TargetSelectPlugin;
+
+impl Plugin for TargetSelectPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<HoveredTarget>()
+            .add_systems(Update, update_hovered_target);
+    }
+}
+
+fn update_hovered_target(
+    camera_q: Query<(&Camera, &GlobalTransform), With<OrbitCamera>>,
+    windows: Query<&Window>,
+    enemies: Query<
+        (Entity, &WorldPosition, &CombatParticipant),
+        (With<ExperienceReward>, Without<Pacifist>),
+    >,
+    mut hovered: ResMut<HoveredTarget>,
+    egui_consumed: Option<Res<EguiPointerConsumed>>,
+) {
+    hovered.0 = None;
+
+    // Don't pick through egui overlays.
+    if egui_consumed.as_ref().is_some_and(|e| e.0) {
+        return;
+    }
+
+    let Ok(window) = windows.single() else { return };
+    let Some(cursor_pos) = window.cursor_position() else { return };
+    let Ok((camera, camera_transform)) = camera_q.single() else { return };
+
+    let mut closest: Option<(Entity, f32, Uuid)> = None;
+
+    for (entity, world_pos, participant) in &enemies {
+        // WorldPosition (x, y, z_elevation) → Bevy world (x, z_elevation, y).
+        // Offset upward by ~0.9 units to hit the torso rather than the feet.
+        let bevy_pos = Vec3::new(world_pos.x, world_pos.z + 0.9, world_pos.y);
+        if let Ok(screen_pos) = camera.world_to_viewport(camera_transform, bevy_pos) {
+            let dist = cursor_pos.distance(screen_pos);
+            if dist < PICK_RADIUS_PX {
+                if closest.is_none() || dist < closest.as_ref().unwrap().1 {
+                    closest = Some((entity, dist, participant.id.0));
+                }
+            }
+        }
+    }
+
+    hovered.0 = closest.map(|(e, _, uuid)| (e, uuid));
+}

--- a/crates/server/src/plugins/combat.rs
+++ b/crates/server/src/plugins/combat.rs
@@ -586,12 +586,28 @@ fn resolve_interrupts(
 
     // ── Phase 3: step each non-empty interrupt stack ─────────────────────────
     let mut all_effects: Vec<(CombatantId, Entity, Vec<Effect>)> = Vec::new();
+    // (attacker_entity, defender_combatant_id, attack_roll) — for miss/crit detection.
+    let mut attack_meta: Vec<(Entity, CombatantId, i32)> = Vec::new();
     for (entity, mut participant, _, _, _, _, _, _) in participants.iter_mut() {
         if participant.interrupt_stack.is_empty() {
             continue;
         }
+        // Peek at the top frame before step() pops it so we can detect misses and crits.
+        let pending_attack = match participant.interrupt_stack.0.last() {
+            Some(InterruptFrame::ResolvingAttack { ctx }) => {
+                Some((ctx.defender.clone(), ctx.attack_roll))
+            }
+            Some(InterruptFrame::ResolvingDamage { .. })
+            | Some(InterruptFrame::ResolvingAbility { .. })
+            | Some(InterruptFrame::ResolvingMovement { .. })
+            | Some(InterruptFrame::CastingSpell { .. })
+            | None => None,
+        };
         let mut rng_iter = std::iter::from_fn(|| Some(rand::random_range(1..=20)));
         let (effects, _done) = participant.interrupt_stack.step(&combat_state, &mut rng_iter);
+        if let Some((defender_id, attack_roll)) = pending_attack {
+            attack_meta.push((entity, defender_id, attack_roll));
+        }
         if !effects.is_empty() {
             all_effects.push((participant.id.clone(), entity, effects));
         }
@@ -621,14 +637,19 @@ fn resolve_interrupts(
                                 "Damage applied"
                             );
                         }
-                        // Emit client-side particle message.
+                        // Emit client-side combat feedback (particles + floating text).
                         if let Ok(pos) = positions_query.get(target_entity) {
+                            let is_critical = attack_meta.iter()
+                                .any(|(ae, _, roll)| ae == attacker_entity && *roll == 20);
                             damage_writer.write(ClientDamageMsg {
                                 x: pos.x,
                                 y: pos.z,
                                 z: pos.y,
                                 is_spell: false,
                                 spell_color: None,
+                                damage: *amount,
+                                is_miss: false,
+                                is_critical,
                             });
                         }
                     }
@@ -696,7 +717,34 @@ fn resolve_interrupts(
         }
     }
 
-    // ── Phase 4b: apply reputation deltas for kills ──────────────────────────
+    // ── Phase 4b: emit miss messages for attacks that dealt no damage ────────
+    {
+        let damage_dealers: std::collections::HashSet<Entity> = all_effects
+            .iter()
+            .filter(|(_, _, fx)| fx.iter().any(|e| matches!(e, Effect::TakeDamage { .. })))
+            .map(|(_, ae, _)| *ae)
+            .collect();
+        for (attacker_entity, defender_id, _) in &attack_meta {
+            if !damage_dealers.contains(attacker_entity) {
+                if let Some(&defender_entity) = id_to_entity.get(defender_id) {
+                    if let Ok(pos) = positions_query.get(defender_entity) {
+                        damage_writer.write(ClientDamageMsg {
+                            x: pos.x,
+                            y: pos.z,
+                            z: pos.y,
+                            is_spell: false,
+                            spell_color: None,
+                            damage: 0,
+                            is_miss: true,
+                            is_critical: false,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Phase 4c: apply reputation deltas for kills ──────────────────────────
     for (killer_uuid, target_entity) in &reputation_kills {
         if let Ok((_, _, _, _, _, _, Some(fm), rank)) = participants.get(*target_entity) {
             let rank = rank.map(|r| r.0).unwrap_or(fellytip_shared::world::faction::NpcRank::Grunt);

--- a/crates/shared/src/protocol.rs
+++ b/crates/shared/src/protocol.rs
@@ -112,9 +112,9 @@ pub struct ZoneNeighborMessage {
     pub zone_hops: Vec<(ZoneId, u8)>,
 }
 
-/// Sent by the server's `resolve_interrupts` system whenever an entity takes
-/// damage in the single-player host model.  The client particle system reads
-/// this message to spawn hit-effect particles at the target's world position.
+/// Sent by the server's `resolve_interrupts` system whenever an attack resolves
+/// (hit, miss, or critical) in the single-player host model.  The client reads
+/// this to spawn particles and floating combat text.
 ///
 /// MULTIPLAYER: register with MessageRegistry and route over the network.
 #[derive(Serialize, Deserialize, Debug, Clone, Message)]
@@ -128,6 +128,12 @@ pub struct ClientDamageMsg {
     /// Optional spell colour as linear RGBA (fire=orange, frost=cyan, lightning=yellow).
     /// None = melee hit (red burst).
     pub spell_color: Option<[f32; 4]>,
+    /// Damage dealt; 0 for misses.
+    pub damage: i32,
+    /// True when the attack roll missed — no damage was dealt.
+    pub is_miss: bool,
+    /// True when a natural 20 was rolled (damage doubled by SRD rules).
+    pub is_critical: bool,
 }
 
 // ── Plugin ───────────────────────────────────────────────────────────────────

--- a/docs/systems/combat.md
+++ b/docs/systems/combat.md
@@ -50,15 +50,32 @@ Converts `PendingAttack` markers into `InterruptFrame::ResolvingAttack` values p
 Converts `PendingAbility` markers into `InterruptFrame::ResolvingAbility` with pre-rolled dice (`[attack_d20, dmg_d8_1, dmg_d8_2]`) in `AbilityContext.rolls`. Removes the marker.
 
 **`resolve_interrupts`**
-Runs in eight phases each tick:
+Runs in several phases each tick:
 1. Build `id → Entity`, `Entity → XP reward`, and `Entity → player UUID` lookup maps.
 2. Build a `CombatState` snapshot from current `Health`, `CombatParticipant`, and `FactionMember` components. `CombatantSnapshot.faction` is populated from `FactionMember` when present.
-3. Step each non-empty `InterruptStack` once; collect effects.
-4. Apply effects via `get_mut` (avoids borrow conflicts with the step phase). Resolve killer UUID from `GameEntityId` on the attacker.
-4b. Apply faction standing deltas for each kill: look up the dead NPC's `FactionMember` and `FactionNpcRank`, call `kill_standing_delta(rank)`, and mutate `PlayerReputationMap`.
+3. Peek at each non-empty `InterruptStack`'s top frame; if it's `ResolvingAttack`, record `(entity, defender_id, attack_roll)` in `attack_meta` for miss/crit detection. Then call `step()` once per stack; collect effects.
+4. Apply effects via `get_mut` (avoids borrow conflicts with the step phase). For `TakeDamage`, emits `ClientDamageMsg` with `damage`, `is_critical` (attack_roll == 20), and `is_miss: false`. Resolve killer UUID from `GameEntityId` on the attacker.
+4b. Emit miss `ClientDamageMsg` (with `is_miss: true`, `damage: 0`) for any attack that produced no `TakeDamage` effect. The miss is positioned at the defender's world location.
+4c. Apply faction standing deltas for each kill.
 5. Award XP to attackers whose target died.
 6. Emit `WriteStoryEvent` for each death.
 7. Despawn dead entities.
+
+## Client-side combat feedback (`crates/client/src/plugins/`)
+
+**Entity picking (`target_select.rs`)**
+Each frame, projects every hostile entity's world position to viewport coordinates using `Camera::world_to_viewport`. The closest enemy within `PICK_RADIUS_PX` (60 px) of the cursor is stored in `HoveredTarget`. Left-clicking with a `HoveredTarget` sets the `target_uuid` in the attack intent, directing the server to attack that specific enemy.
+
+**Context menu (`action_menu.rs`)**
+Right-clicking captures the current `HoveredTarget` into `ActionMenuState.context`. If a hostile entity is hovered (`TargetContext::Hostile { uuid }`), the menu shows targeted combat options (Attack, Shove stub, Grapple stub, Class Action). Otherwise, a generic tile/empty-space menu is shown (Attack nearest, Ability, Dodge, Examine stub).
+
+**Floating combat text (`floating_text.rs`)**
+Listens to `ClientDamageMsg`. Each message spawns a `FloatEntry` in `FloatingTextQueue`:
+- Hit: white number, 14 px, fades over 1.2 s
+- Miss: grey "Miss!", 13 px, fades over 1.0 s
+- Critical hit: gold `"<dmg>!"`, 20 px, fades over 1.5 s
+
+Text positions are projected to screen each frame and float upward 40 px over the entry's lifetime.
 
 ## Levelling
 


### PR DESCRIPTION
Implements issue #123: mouse-driven combat

- Left-click on hovered hostile entity fires targeted BasicAttack via UUID; falls back to attack-nearest
- Entity picking (target_select.rs): screen-space projection finds closest enemy within 60 px
- Context-sensitive right-click menu: hostile vs. tile/empty options
- Floating combat text: damage numbers, "Miss!", gold critical hits
- Extended ClientDamageMsg with damage/miss/crit fields; server emits miss messages

Generated with [Claude Code](https://claude.ai/code)