### PR TITLE
feat: NpcClass + NpcLevel ECS components on all sentient NPCs (#099)

### DIFF
--- a/crates/server/src/plugins/ai/population.rs
+++ b/crates/server/src/plugins/ai/population.rs
@@ -17,7 +17,7 @@ use fellytip_shared::{
         types::{CharacterClass, CombatantId},
         SpellSlots, Spellbook,
     },
-    components::{EconomicRole, EconomicRoleKind, EntityKind, FactionBadge, GrowthStage, Health, NavPath, NavReplanTimer, PlayerStandings, WorldPosition},
+    components::{AbilityModifiers, AbilityScores, EconomicRole, EconomicRoleKind, EntityKind, FactionBadge, GrowthStage, Health, HitDice, NavPath, NavReplanTimer, NpcClass, NpcLevel, PlayerStandings, SavingThrowProficiencies, WorldPosition},
     world::{
         civilization::{AbandonedSettlement, RuinsTile, SettlementKind, Settlements},
         ecology::RegionId,
@@ -175,17 +175,15 @@ pub(crate) fn faction_npc_bundle(
     level: u32,
 ) -> impl Bundle {
     let class = class_for_faction_grunt(&faction_id, 0);
-    let scores = fellytip_shared::components::AbilityScores::for_class(
-        &class,
-        fellytip_shared::world::faction::NpcRank::Grunt,
-    );
+    let scores = AbilityScores::for_class(&class, NpcRank::Grunt);
+    let modifiers = AbilityModifiers::from_scores(&scores);
     (
         pos.clone(),
         Health { current: 20, max: 20 },
         crate::plugins::combat::CombatParticipant {
             id: CombatantId(Uuid::new_v4()),
             interrupt_stack: InterruptStack::default(),
-            class,
+            class: class.clone(),
             level,
             // Leather armour, DEX 10 → AC 11 (SRD: 11 + DEX mod)
             armor_class: 11,
@@ -203,6 +201,17 @@ pub(crate) fn faction_npc_bundle(
         CurrentGoal(None),
         HomePosition(pos),
         EntityKind::FactionNpc,
+        // Class/level/ability-score bundle (nested to stay within tuple Bundle limit).
+        (
+            NpcClass(class.clone()),
+            NpcLevel(level),
+            scores,
+            modifiers,
+            HitDice::for_class_level(&class, level),
+            SavingThrowProficiencies::for_class(&class),
+            SpellSlots::for_class(&class, level as u8),
+            Spellbook::for_class(&class),
+        ),
     )
 }
 
@@ -299,10 +308,8 @@ pub fn spawn_faction_npcs(
                 z: settlement.z,
             };
             let npc_class = class_for_faction_grunt(&faction.id, npc_idx);
-            let scores = fellytip_shared::components::AbilityScores::for_class(
-                &npc_class,
-                NpcRank::Grunt,
-            );
+            let scores = AbilityScores::for_class(&npc_class, NpcRank::Grunt);
+            let modifiers = AbilityModifiers::from_scores(&scores);
             let economic_role = assign_economic_role(
                 npc_idx,
                 is_capital,
@@ -334,8 +341,17 @@ pub fn spawn_faction_npcs(
                 NavPath::default(),
                 NavReplanTimer::default(),
                 economic_role,
-                SpellSlots::for_class(&npc_class, 1),
-                Spellbook::for_class(&npc_class),
+                // Class/level/ability-score bundle (nested to stay within tuple Bundle limit).
+                (
+                    NpcClass(npc_class.clone()),
+                    NpcLevel(1),
+                    scores,
+                    modifiers,
+                    HitDice::for_class_level(&npc_class, 1),
+                    SavingThrowProficiencies::for_class(&npc_class),
+                    SpellSlots::for_class(&npc_class, 1),
+                    Spellbook::for_class(&npc_class),
+                ),
             ));
             tracing::debug!(
                 faction = %faction.name,
@@ -533,6 +549,8 @@ pub fn tick_population_system(
                         &next.faction_id,
                         tick.0 as usize,
                     );
+                    let child_scores = AbilityScores::for_class(&child_class, NpcRank::Grunt);
+                    let child_mods = AbilityModifiers::from_scores(&child_scores);
                     commands.spawn((
                         pos.clone(),
                         Health { current: 5, max: 5 },
@@ -542,12 +560,12 @@ pub fn tick_population_system(
                             class: child_class.clone(),
                             level: 1,
                             armor_class: 8,
-                            strength: 8,
-                            dexterity: 8,
-                            constitution: 8,
-                            intelligence: 10,
-                            wisdom: 10,
-                            charisma: 10,
+                            strength: child_scores.strength as i32,
+                            dexterity: child_scores.dexterity as i32,
+                            constitution: child_scores.constitution as i32,
+                            intelligence: child_scores.intelligence as i32,
+                            wisdom: child_scores.wisdom as i32,
+                            charisma: child_scores.charisma as i32,
                         },
                         ExperienceReward(5),
                         FactionMember(next.faction_id.clone()),
@@ -559,8 +577,17 @@ pub fn tick_population_system(
                         GrowthStage(0.0),
                         NavPath::default(),
                         NavReplanTimer::default(),
-                        SpellSlots::for_class(&child_class, 1),
-                        Spellbook::for_class(&child_class),
+                        // Class/level/ability-score bundle (nested to stay within tuple Bundle limit).
+                        (
+                            NpcClass(child_class.clone()),
+                            NpcLevel(1),
+                            child_scores,
+                            child_mods,
+                            HitDice::for_class_level(&child_class, 1),
+                            SavingThrowProficiencies::for_class(&child_class),
+                            SpellSlots::for_class(&child_class, 1),
+                            Spellbook::for_class(&child_class),
+                        ),
                     ));
                     tracing::debug!(faction = %next.faction_id.0, "Child NPC spawned");
                 }
@@ -577,6 +604,8 @@ pub fn tick_population_system(
                     let jitter = ((tick.0 as f32 * 0.47).sin() * 0.5, (tick.0 as f32 * 0.71).cos() * 0.5);
                     let pos = WorldPosition { x: x + jitter.0, y: y + jitter.1, z };
                     let child_class = class_for_faction_grunt(&next.faction_id, tick.0 as usize + 1);
+                    let econ_scores = AbilityScores::for_class(&child_class, NpcRank::Grunt);
+                    let econ_mods = AbilityModifiers::from_scores(&econ_scores);
                     commands.spawn((
                         pos.clone(),
                         Health { current: 5, max: 5 },
@@ -586,12 +615,12 @@ pub fn tick_population_system(
                             class: child_class.clone(),
                             level: 1,
                             armor_class: 8,
-                            strength: 8,
-                            dexterity: 8,
-                            constitution: 8,
-                            intelligence: 10,
-                            wisdom: 10,
-                            charisma: 10,
+                            strength: econ_scores.strength as i32,
+                            dexterity: econ_scores.dexterity as i32,
+                            constitution: econ_scores.constitution as i32,
+                            intelligence: econ_scores.intelligence as i32,
+                            wisdom: econ_scores.wisdom as i32,
+                            charisma: econ_scores.charisma as i32,
                         },
                         ExperienceReward(5),
                         FactionMember(next.faction_id.clone()),
@@ -603,8 +632,17 @@ pub fn tick_population_system(
                         GrowthStage(0.0),
                         NavPath::default(),
                         NavReplanTimer::default(),
-                        SpellSlots::for_class(&child_class, 1),
-                        Spellbook::for_class(&child_class),
+                        // Class/level/ability-score bundle (nested to stay within tuple Bundle limit).
+                        (
+                            NpcClass(child_class.clone()),
+                            NpcLevel(1),
+                            econ_scores,
+                            econ_mods,
+                            HitDice::for_class_level(&child_class, 1),
+                            SavingThrowProficiencies::for_class(&child_class),
+                            SpellSlots::for_class(&child_class, 1),
+                            Spellbook::for_class(&child_class),
+                        ),
                     ));
                     tracing::debug!(faction = %next.faction_id.0, "Economy growth: child NPC spawned");
                 }
@@ -934,10 +972,8 @@ pub fn spawn_underground_raid(
         };
         // Underground raid NPCs: Warlock bias (dark underground class, issue #130).
         let raid_class = class_for_faction_grunt(&underground_fid, i as usize);
-        let raid_scores = fellytip_shared::components::AbilityScores::for_class(
-            &raid_class,
-            NpcRank::Grunt,
-        );
+        let raid_scores = AbilityScores::for_class(&raid_class, NpcRank::Grunt);
+        let raid_mods = AbilityModifiers::from_scores(&raid_scores);
         commands.spawn((
             pos.clone(),
             Health { current: 25, max: 25 },
@@ -972,8 +1008,17 @@ pub fn spawn_underground_raid(
                 zone_route: zone_route.clone(),
             },
             fellytip_shared::world::zone::ZoneMembership(deepest_id),
-            SpellSlots::for_class(&raid_class, 2),
-            Spellbook::for_class(&raid_class),
+            // Class/level/ability-score bundle (nested to stay within tuple Bundle limit).
+            (
+                NpcClass(raid_class.clone()),
+                NpcLevel(2),
+                raid_scores,
+                raid_mods,
+                HitDice::for_class_level(&raid_class, 2),
+                SavingThrowProficiencies::for_class(&raid_class),
+                SpellSlots::for_class(&raid_class, 2),
+                Spellbook::for_class(&raid_class),
+            ),
         ));
     }
 

--- a/crates/server/src/plugins/ai/surface_danger.rs
+++ b/crates/server/src/plugins/ai/surface_danger.rs
@@ -16,7 +16,7 @@ use fellytip_shared::{
         interrupt::InterruptStack,
         types::{CharacterClass, CombatantId},
     },
-    components::{EntityKind, FactionBadge, Health, NavPath, NavReplanTimer, PlayerStandings, WorldPosition},
+    components::{AbilityModifiers, AbilityScores, EntityKind, FactionBadge, Health, HitDice, NavPath, NavReplanTimer, NpcClass, NpcLevel, PlayerStandings, SavingThrowProficiencies, WorldPosition},
     world::{
         civilization::Settlements,
         faction::{FactionId, NpcRank, PlayerReputationMap},
@@ -330,8 +330,9 @@ pub fn spawn_bandit_groups(
             } else {
                 CharacterClass::Barbarian
             };
-            let scores =
-                fellytip_shared::components::AbilityScores::for_class(&class, rank);
+            let scores = AbilityScores::for_class(&class, rank);
+            let mods = AbilityModifiers::from_scores(&scores);
+            let level = if rank == NpcRank::Named { 3 } else { 1 };
             let (hp, ac, xp_reward) = match rank {
                 NpcRank::Grunt => (20, 12, 50),
                 NpcRank::Named => (35, 14, 200),
@@ -346,8 +347,8 @@ pub fn spawn_bandit_groups(
                 CombatParticipant {
                     id: CombatantId(Uuid::new_v4()),
                     interrupt_stack: InterruptStack::default(),
-                    class,
-                    level: if rank == NpcRank::Named { 3 } else { 1 },
+                    class: class.clone(),
+                    level,
                     armor_class: ac,
                     strength: scores.strength as i32,
                     dexterity: scores.dexterity as i32,
@@ -372,6 +373,15 @@ pub fn spawn_bandit_groups(
                 },
                 NavPath::default(),
                 NavReplanTimer::default(),
+                // Class/level/ability-score bundle (nested to stay within tuple Bundle limit).
+                (
+                    NpcClass(class.clone()),
+                    NpcLevel(level),
+                    scores,
+                    mods,
+                    HitDice::for_class_level(&class, level),
+                    SavingThrowProficiencies::for_class(&class),
+                ),
             ));
         }
 
@@ -423,6 +433,8 @@ pub fn spawn_portal_horrors(
         let jx = ((jitter_seed % 5) as f32) - 2.0;
         let jy = ((jitter_seed.wrapping_mul(17) % 5) as f32) - 2.0;
         let pos = WorldPosition { x: jx, y: jy, z: 0.0 };
+        let warlock_scores = AbilityScores { strength: 10, dexterity: 14, constitution: 14, intelligence: 14, wisdom: 12, charisma: 18 };
+        let warlock_mods = AbilityModifiers::from_scores(&warlock_scores);
         commands.spawn((
             pos.clone(),
             Health { current: 45, max: 45 },
@@ -432,12 +444,12 @@ pub fn spawn_portal_horrors(
                 class: CharacterClass::Warlock,
                 level: 3,
                 armor_class: 13,
-                strength: 10,
-                dexterity: 14,
-                constitution: 14,
-                intelligence: 14,
-                wisdom: 12,
-                charisma: 18,
+                strength: warlock_scores.strength as i32,
+                dexterity: warlock_scores.dexterity as i32,
+                constitution: warlock_scores.constitution as i32,
+                intelligence: warlock_scores.intelligence as i32,
+                wisdom: warlock_scores.wisdom as i32,
+                charisma: warlock_scores.charisma as i32,
             },
             ExperienceReward(700),
             FactionNpcRank(NpcRank::Named),
@@ -446,6 +458,15 @@ pub fn spawn_portal_horrors(
             PortalHorror { world_origin: WORLD_DEVILS_CASINO },
             NavPath::default(),
             NavReplanTimer::default(),
+            // Class/level/ability-score bundle (nested to stay within tuple Bundle limit).
+            (
+                NpcClass(CharacterClass::Warlock),
+                NpcLevel(3),
+                warlock_scores,
+                warlock_mods,
+                HitDice::for_class_level(&CharacterClass::Warlock, 3),
+                SavingThrowProficiencies::for_class(&CharacterClass::Warlock),
+            ),
         ));
         tracing::info!(portal_id = portal.id, "Void Gambler spawned from CasinoPortal");
     }
@@ -456,6 +477,8 @@ pub fn spawn_portal_horrors(
         let jx = ((jitter_seed % 5) as f32) - 2.0;
         let jy = ((jitter_seed.wrapping_mul(23) % 5) as f32) - 2.0;
         let pos = WorldPosition { x: jx, y: jy, z: 0.0 };
+        let druid_scores = AbilityScores { strength: 10, dexterity: 12, constitution: 14, intelligence: 12, wisdom: 16, charisma: 10 };
+        let druid_mods = AbilityModifiers::from_scores(&druid_scores);
         commands.spawn((
             pos.clone(),
             Health { current: 33, max: 33 },
@@ -465,12 +488,12 @@ pub fn spawn_portal_horrors(
                 class: CharacterClass::Druid,
                 level: 2,
                 armor_class: 11,
-                strength: 10,
-                dexterity: 12,
-                constitution: 14,
-                intelligence: 12,
-                wisdom: 16,
-                charisma: 10,
+                strength: druid_scores.strength as i32,
+                dexterity: druid_scores.dexterity as i32,
+                constitution: druid_scores.constitution as i32,
+                intelligence: druid_scores.intelligence as i32,
+                wisdom: druid_scores.wisdom as i32,
+                charisma: druid_scores.charisma as i32,
             },
             ExperienceReward(450),
             FactionNpcRank(NpcRank::Named),
@@ -479,6 +502,15 @@ pub fn spawn_portal_horrors(
             PortalHorror { world_origin: WORLD_HIVEMIND_FUNGUS },
             NavPath::default(),
             NavReplanTimer::default(),
+            // Class/level/ability-score bundle (nested to stay within tuple Bundle limit).
+            (
+                NpcClass(CharacterClass::Druid),
+                NpcLevel(2),
+                druid_scores,
+                druid_mods,
+                HitDice::for_class_level(&CharacterClass::Druid, 2),
+                SavingThrowProficiencies::for_class(&CharacterClass::Druid),
+            ),
         ));
         tracing::info!(portal_id = portal.id, "Spore Wraith spawned from FungusPortal");
     }
@@ -690,11 +722,12 @@ pub fn update_threat_registry(
 fn spawn_bounty_hunter(commands: &mut Commands, near: &WorldPosition, rank: NpcRank, tick: u64) {
     let iron_wolves = FactionId(SmolStr::new("iron_wolves"));
     let class = CharacterClass::Ranger;
-    let scores = fellytip_shared::components::AbilityScores::for_class(&class, rank);
+    let scores = AbilityScores::for_class(&class, rank);
+    let mods = AbilityModifiers::from_scores(&scores);
     let (hp, ac, level, xp_reward) = match rank {
-        NpcRank::Grunt => (20, 13, 1, 50),
-        NpcRank::Named => (40, 15, 5, 300),
-        NpcRank::Boss => (65, 17, 8, 700),
+        NpcRank::Grunt => (20, 13, 1u32, 50),
+        NpcRank::Named => (40, 15, 5u32, 300),
+        NpcRank::Boss => (65, 17, 8u32, 700),
     };
     // Spawn slightly offset from player position.
     let offset = (tick % 5) as f32 * 3.0 + 5.0;
@@ -709,7 +742,7 @@ fn spawn_bounty_hunter(commands: &mut Commands, near: &WorldPosition, rank: NpcR
         CombatParticipant {
             id: CombatantId(Uuid::new_v4()),
             interrupt_stack: InterruptStack::default(),
-            class,
+            class: class.clone(),
             level,
             armor_class: ac,
             strength: scores.strength as i32,
@@ -728,6 +761,15 @@ fn spawn_bounty_hunter(commands: &mut Commands, near: &WorldPosition, rank: NpcR
         EntityKind::FactionNpc,
         NavPath::default(),
         NavReplanTimer::default(),
+        // Class/level/ability-score bundle (nested to stay within tuple Bundle limit).
+        (
+            NpcClass(class.clone()),
+            NpcLevel(level),
+            scores,
+            mods,
+            HitDice::for_class_level(&class, level),
+            SavingThrowProficiencies::for_class(&class),
+        ),
     ));
 }
 

--- a/crates/shared/src/combat/types.rs
+++ b/crates/shared/src/combat/types.rs
@@ -3,6 +3,7 @@
 //! All types here are pure data — no ECS, no I/O.
 
 use crate::world::faction::FactionId;
+use bevy::reflect::Reflect;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use uuid::Uuid;
@@ -39,7 +40,7 @@ impl Default for CoreStats {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Reflect)]
 pub enum CharacterClass {
     // ── Legacy player-facing aliases (kept for save compatibility) ────────────
     Warrior,

--- a/crates/shared/src/components.rs
+++ b/crates/shared/src/components.rs
@@ -282,6 +282,31 @@ pub struct Pacifist;
 #[reflect(Component)]
 pub struct PendingAsi;
 
+// ── NPC Class + Level ──────────────────────────────────────────────────────────
+
+/// The character class of a sentient NPC — added to all faction NPCs at spawn.
+///
+/// Drives ability score arrays (`AbilityScores::for_class`), combat action
+/// selection (`npc_ability_id` in the combat plugin), dialogue flavor
+/// (`greeting_flavor`), and behavior profiles.
+#[derive(
+    Component, Clone, PartialEq, Debug,
+    Serialize, Deserialize, Reflect,
+)]
+#[reflect(Component)]
+pub struct NpcClass(pub CharacterClass);
+
+/// The current level of a sentient NPC — added to all faction NPCs at spawn.
+///
+/// Affects proficiency bonus, hit dice count, and ASI thresholds.
+/// See `proficiency_bonus()` in `crates/shared/src/combat/types.rs`.
+#[derive(
+    Component, Clone, PartialEq, Debug, Default,
+    Serialize, Deserialize, Reflect,
+)]
+#[reflect(Component)]
+pub struct NpcLevel(pub u32);
+
 // ── D&D 5e SRD Ability Scores ─────────────────────────────────────────────────
 
 /// The six D&D 5e SRD ability scores for a character or NPC.
@@ -1061,5 +1086,42 @@ mod tests {
         let at_cap = AbilityScores { strength: 20, dexterity: 10, constitution: 10, intelligence: 10, wisdom: 10, charisma: 10 };
         let after2 = at_cap.with_npc_asi(&CharacterClass::Warrior);
         assert_eq!(after2.strength, 20);
+    }
+
+    #[test]
+    fn npc_class_wraps_character_class() {
+        use crate::combat::types::CharacterClass;
+        let cls = NpcClass(CharacterClass::Fighter);
+        assert_eq!(cls.0, CharacterClass::Fighter);
+        let cls2 = NpcClass(CharacterClass::Warlock);
+        assert_ne!(cls, cls2);
+    }
+
+    #[test]
+    fn npc_level_default_is_zero() {
+        let lvl = NpcLevel::default();
+        assert_eq!(lvl.0, 0);
+    }
+
+    #[test]
+    fn npc_level_serde_round_trip() {
+        let lvl = NpcLevel(5);
+        let json = serde_json::to_string(&lvl).unwrap();
+        let back: NpcLevel = serde_json::from_str(&json).unwrap();
+        assert_eq!(lvl, back);
+    }
+
+    #[test]
+    fn npc_class_serde_round_trip() {
+        use crate::combat::types::CharacterClass;
+        for class in [
+            CharacterClass::Fighter, CharacterClass::Wizard, CharacterClass::Rogue,
+            CharacterClass::Warlock, CharacterClass::Druid, CharacterClass::Barbarian,
+        ] {
+            let c = NpcClass(class.clone());
+            let json = serde_json::to_string(&c).unwrap();
+            let back: NpcClass = serde_json::from_str(&json).unwrap();
+            assert_eq!(c, back);
+        }
     }
 }

--- a/crates/shared/src/protocol.rs
+++ b/crates/shared/src/protocol.rs
@@ -9,7 +9,7 @@
 use bevy::ecs::message::Message;
 use bevy::prelude::*;
 use crate::combat::types::CharacterClass;
-use crate::components::{ActionBudget, EntityBounds, EntityKind, Experience, FactionBadge, GrowthStage, Health, PlayerStandings, SavingThrowProficiencies, WildlifeKind, WorldMeta, WorldPosition};
+use crate::components::{ActionBudget, EntityBounds, EntityKind, Experience, FactionBadge, GrowthStage, Health, NpcClass, NpcLevel, PlayerStandings, SavingThrowProficiencies, WildlifeKind, WorldMeta, WorldPosition};
 use crate::world::story::GameEntityId;
 use crate::world::zone::{InteriorTile, Portal, WorldId, ZoneAnchor, ZoneId, ZoneKind};
 use serde::{Deserialize, Serialize};
@@ -157,6 +157,9 @@ impl Plugin for FellytipProtocolPlugin {
         app.register_type::<GameEntityId>();
         app.register_type::<SavingThrowProficiencies>();
         app.register_type::<ActionBudget>();
+        app.register_type::<CharacterClass>();
+        app.register_type::<NpcClass>();
+        app.register_type::<NpcLevel>();
         // ChooseClassMessage flows client→server; must be registered before
         // MessageWriter/MessageReader can be used.
         app.add_message::<ChooseClassMessage>();


### PR DESCRIPTION
Closes #99

Adds `NpcClass` and `NpcLevel` as standalone ECS components on every sentient NPC, wires up `AbilityScores`/`HitDice`/`SavingThrowProficiencies` across all 6 spawn paths, and fixes the DM bundle missing SpellSlots/Spellbook.

Generated with [Claude Code](https://claude.ai/code)