### PR TITLE
fix(player): complete class serialization + add class/spell-slot HUD

### DIFF
--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -621,9 +621,21 @@ fn dm_choose_class(
         .to_owned();
 
     let class = match class_str.as_str() {
-        "Rogue"  => CharacterClass::Rogue,
-        "Mage"   => CharacterClass::Mage,
-        _        => CharacterClass::Warrior,
+        "Warrior"   => CharacterClass::Warrior,
+        "Rogue"     => CharacterClass::Rogue,
+        "Mage"      => CharacterClass::Mage,
+        "Fighter"   => CharacterClass::Fighter,
+        "Wizard"    => CharacterClass::Wizard,
+        "Cleric"    => CharacterClass::Cleric,
+        "Ranger"    => CharacterClass::Ranger,
+        "Paladin"   => CharacterClass::Paladin,
+        "Druid"     => CharacterClass::Druid,
+        "Bard"      => CharacterClass::Bard,
+        "Warlock"   => CharacterClass::Warlock,
+        "Sorcerer"  => CharacterClass::Sorcerer,
+        "Monk"      => CharacterClass::Monk,
+        "Barbarian" => CharacterClass::Barbarian,
+        _           => CharacterClass::Warrior,
     };
 
     world.write_message(ChooseClassMessage { class });

--- a/crates/client/src/plugins/hud.rs
+++ b/crates/client/src/plugins/hud.rs
@@ -11,10 +11,11 @@
 use bevy::prelude::*;
 use bevy_egui::{EguiContext, EguiContexts, EguiGlobalSettings, EguiPlugin, EguiPrimaryContextPass, PrimaryEguiContext, egui};
 use fellytip_shared::{
+    combat::spells::SpellSlots,
     components::{ActionBudget, Experience, Health, PlayerStandings},
     world::faction::standing_tier,
 };
-use fellytip_server::plugins::party::PartyRegistry;
+use fellytip_server::plugins::{combat::CombatParticipant, party::PartyRegistry};
 use crate::LocalPlayer;
 use crate::plugins::battle::{BattleLog, ClientStoryLog};
 use crate::plugins::debug_console::DebugConsole;
@@ -28,6 +29,19 @@ type LocalPlayerQuery<'w, 's> = Query<
         &'static Experience,
         Option<&'static PlayerStandings>,
         Option<&'static ActionBudget>,
+    ),
+    With<LocalPlayer>,
+>;
+
+type CharScreenQuery<'w, 's> = Query<
+    'w,
+    's,
+    (
+        &'static Health,
+        &'static Experience,
+        Option<&'static PlayerStandings>,
+        Option<&'static CombatParticipant>,
+        Option<&'static SpellSlots>,
     ),
     With<LocalPlayer>,
 >;
@@ -193,7 +207,7 @@ fn draw_party_hud(
 /// Draw the character screen overlay when 'C' is pressed.
 fn draw_char_screen(
     mut ctx: EguiContexts,
-    player_q: LocalPlayerQuery,
+    player_q: CharScreenQuery,
     mut char_screen: ResMut<CharScreen>,
 ) -> Result {
     if !char_screen.open {
@@ -206,8 +220,12 @@ fn draw_char_screen(
         .open(&mut open)
         .show(ctx.ctx_mut()?, |ui| {
             match player_q.single() {
-                Ok((health, exp, standings_opt, _)) => {
-                    ui.heading(format!("Level {}", exp.level));
+                Ok((health, exp, standings_opt, participant_opt, slots_opt)) => {
+                    if let Some(p) = participant_opt {
+                        ui.heading(format!("{:?}  —  Level {}", p.class, exp.level));
+                    } else {
+                        ui.heading(format!("Level {}", exp.level));
+                    }
                     ui.separator();
 
                     egui::Grid::new("char_stats").num_columns(2).spacing([20.0, 4.0]).show(ui, |ui| {
@@ -217,7 +235,43 @@ fn draw_char_screen(
                         ui.label("Experience:");
                         ui.label(format!("{}/{}", exp.xp, exp.xp_to_next));
                         ui.end_row();
+                        if let Some(p) = participant_opt {
+                            ui.label("Armour Class:");
+                            ui.label(format!("{}", p.armor_class));
+                            ui.end_row();
+                        }
                     });
+
+                    // Spell slots (spellcasting classes only).
+                    if let Some(slots) = slots_opt {
+                        let has_any = slots.max_slots.iter().any(|&s| s > 0);
+                        if has_any {
+                            ui.separator();
+                            ui.heading("Spell Slots");
+                            ui.separator();
+                            egui::Grid::new("spell_slots").num_columns(3).spacing([10.0, 2.0]).show(ui, |ui| {
+                                ui.label("Level");
+                                ui.label("Used");
+                                ui.label("Max");
+                                ui.end_row();
+                                for level in 1..9usize {
+                                    let max = slots.max_slots[level];
+                                    if max > 0 {
+                                        let used = slots.used_slots[level];
+                                        let color = if used < max {
+                                            egui::Color32::from_rgb(100, 200, 100)
+                                        } else {
+                                            egui::Color32::from_rgb(140, 140, 140)
+                                        };
+                                        ui.colored_label(color, format!("{level}"));
+                                        ui.colored_label(color, format!("{used}"));
+                                        ui.colored_label(color, format!("{max}"));
+                                        ui.end_row();
+                                    }
+                                }
+                            });
+                        }
+                    }
 
                     ui.separator();
                     ui.heading("Faction Standing");

--- a/crates/server/src/plugins/character_persistence.rs
+++ b/crates/server/src/plugins/character_persistence.rs
@@ -63,9 +63,21 @@ pub fn class_to_str(class: &CharacterClass) -> &'static str {
 
 pub fn class_from_str(s: &str) -> CharacterClass {
     match s {
-        "Rogue" => CharacterClass::Rogue,
-        "Mage"  => CharacterClass::Mage,
-        _       => CharacterClass::Warrior,
+        "Warrior"   => CharacterClass::Warrior,
+        "Rogue"     => CharacterClass::Rogue,
+        "Mage"      => CharacterClass::Mage,
+        "Fighter"   => CharacterClass::Fighter,
+        "Wizard"    => CharacterClass::Wizard,
+        "Cleric"    => CharacterClass::Cleric,
+        "Ranger"    => CharacterClass::Ranger,
+        "Paladin"   => CharacterClass::Paladin,
+        "Druid"     => CharacterClass::Druid,
+        "Bard"      => CharacterClass::Bard,
+        "Warlock"   => CharacterClass::Warlock,
+        "Sorcerer"  => CharacterClass::Sorcerer,
+        "Monk"      => CharacterClass::Monk,
+        "Barbarian" => CharacterClass::Barbarian,
+        _           => CharacterClass::Warrior,
     }
 }
 
@@ -289,5 +301,44 @@ fn autosave_players(
             pos.y,
             pos.z,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn class_roundtrip_all_classes() {
+        let classes = [
+            CharacterClass::Warrior,
+            CharacterClass::Rogue,
+            CharacterClass::Mage,
+            CharacterClass::Fighter,
+            CharacterClass::Wizard,
+            CharacterClass::Cleric,
+            CharacterClass::Ranger,
+            CharacterClass::Paladin,
+            CharacterClass::Druid,
+            CharacterClass::Bard,
+            CharacterClass::Warlock,
+            CharacterClass::Sorcerer,
+            CharacterClass::Monk,
+            CharacterClass::Barbarian,
+        ];
+        for class in &classes {
+            let s = class_to_str(class);
+            let back = class_from_str(s);
+            assert_eq!(
+                std::mem::discriminant(class),
+                std::mem::discriminant(&back),
+                "class_from_str({s:?}) did not round-trip back to the same variant"
+            );
+        }
+    }
+
+    #[test]
+    fn class_from_str_unknown_defaults_to_warrior() {
+        assert!(matches!(class_from_str("Barbarian Warrior"), CharacterClass::Warrior));
     }
 }


### PR DESCRIPTION
Fixes #098

**Bugs fixed:**
- `class_from_str()` now handles all 14 classes; previously only Rogue and Mage were decoded — every other class silently reloaded as Warrior
- `dm/choose_class` BRP method now accepts all 14 class names

**New features:**
- Character screen ('C' key) now shows class name, armour class, and a spell-slot grid for spellcasting classes
- Roundtrip unit tests for class serialization

Generated with [Claude Code](https://claude.ai/code)