### PR TITLE
perf: fix SSAO/MSAA conflict, bump dev opt-level to 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,8 @@ color_quant         = "1"
 avian3d             = { version = "0.6", features = ["3d", "f32"] }
 fellytip-shared     = { path = "crates/shared" }
 
+[profile.dev]
+opt-level = 2
+
 [profile.dev.package."*"]
 opt-level = 3

--- a/crates/client/src/plugins/camera.rs
+++ b/crates/client/src/plugins/camera.rs
@@ -9,7 +9,7 @@
 use bevy::core_pipeline::tonemapping::Tonemapping;
 use bevy::input::mouse::AccumulatedMouseMotion;
 use bevy::input::mouse::AccumulatedMouseScroll;
-use bevy::pbr::{DistanceFog, FogFalloff, ScreenSpaceAmbientOcclusion};
+use bevy::pbr::{DistanceFog, FogFalloff};
 use bevy::post_process::bloom::{Bloom, BloomCompositeMode, BloomPrefilter};
 use bevy::prelude::*;
 use bevy::render::view::{ColorGrading, ColorGradingGlobal};
@@ -116,7 +116,6 @@ fn spawn_camera(mut commands: Commands) {
             directional_light_color: Color::srgba(1.0, 0.95, 0.85, 0.5),
             directional_light_exponent: 30.0,
         },
-        ScreenSpaceAmbientOcclusion::default(),
         ColorGrading {
             global: ColorGradingGlobal {
                 exposure: 0.0,

--- a/crates/client/src/plugins/settings.rs
+++ b/crates/client/src/plugins/settings.rs
@@ -55,7 +55,7 @@ impl Default for GraphicsSettings {
         Self {
             bloom: true,
             bloom_intensity: 0.15,
-            ssao: true,
+            ssao: false,
             fog: true,
             fog_density: 0.008,
             animated_water: true,


### PR DESCRIPTION
- Remove ScreenSpaceAmbientOcclusion from camera spawn (requires Msaa::Off but game uses Msaa::Sample4, causing 1 FPS render stall every frame)
- Set ssao default to false in settings
- Add profile.dev opt-level = 2 for first-party crates (deps already at 3)